### PR TITLE
Report agent memory usage, other small improvements

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -44,12 +44,13 @@ func newProfileOpts() *options.PrintOpts {
 	}
 }
 
-func getProfiles() *jnode.Node {
+func getProfiles(names []string) *jnode.Node {
 	n := jnode.NewObjectNode()
 	a := n.PutArray("profiles")
-	names := []string{}
-	for name := range config.GlobalConfig.Profiles {
-		names = append(names, name)
+	if names == nil {
+		for name := range config.GlobalConfig.Profiles {
+			names = append(names, name)
+		}
 	}
 	sort.Strings(names)
 	for _, name := range names {
@@ -82,7 +83,7 @@ func setProfileCmd() *cobra.Command {
 				}
 			}
 			config.Save()
-			opts.PrintResult(getProfiles())
+			opts.PrintResult(getProfiles([]string{name}))
 			return nil
 		},
 	}
@@ -121,7 +122,7 @@ func updateProfileCmd() *cobra.Command {
 			default:
 				return fmt.Errorf("either --delete or --rename must be given")
 			}
-			opts.PrintResult(getProfiles())
+			opts.PrintResult(getProfiles(nil))
 			return nil
 		},
 	}
@@ -138,7 +139,7 @@ func listProfilesCmd() *cobra.Command {
 		Use:   "list-profiles",
 		Short: "Lists the CLI profiles",
 		Run: func(cmd *cobra.Command, args []string) {
-			opts.PrintResult(getProfiles())
+			opts.PrintResult(getProfiles(nil))
 		},
 	}
 	opts.Register(c)

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/models/agent.hcl
+++ b/models/agent.hcl
@@ -46,4 +46,22 @@ command "group" "agent" {
       usage = "The base repository to upgrade to"
     }
   }
+  command "print_cluster" "list" {
+    short = "List agents"
+    cluster_id_optional = true
+    path = "org/{org}/agents"
+    method = "GET"
+    result {
+      path = [ "agents" ]
+      columns = [
+        "agentInstanceId", "clusterId", "agentVersion", "agentStartTs", "updateTs",
+        "agentRemoteIp", "memAlloc", "message"
+      ]
+      formatters = {
+        "memAlloc": "bytes"
+        "updateTs": "relative_ts"
+        "message": "first_message"
+      }
+    }
+  }
 }

--- a/models/job.hcl
+++ b/models/job.hcl
@@ -44,6 +44,7 @@ command "group" "job" {
     parameter "jobID" {
       usage       = "The job id"
       disposition = "context"
+      required = true
     }
   }
   command "print_client" "cancel" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ var ConfigFile string
 const Redacted = "*** redacted ***"
 
 type ProfileT struct {
+	ProfileName      string `json:"-"`
 	APIServer        string
 	APIToken         string
 	TLSNoVerify      bool
@@ -58,6 +59,7 @@ func SelectProfile(name string) bool {
 		result = true
 	}
 	GlobalConfig.CurrentProfile = name
+	Config.ProfileName = name
 	return result
 }
 
@@ -70,6 +72,7 @@ func CopyProfile(sourceName string) error {
 		return fmt.Errorf("no source profile %s to copy from", sourceName)
 	}
 	copy := *source
+	copy.ProfileName = GlobalConfig.CurrentProfile
 	GlobalConfig.Profiles[GlobalConfig.CurrentProfile] = &copy
 	SelectProfile(GlobalConfig.CurrentProfile)
 	return nil
@@ -99,6 +102,7 @@ func RenameProfile(name, rename string) error {
 		return fmt.Errorf("cannot rename non-existent profile %s", name)
 	}
 	GlobalConfig.Profiles[rename] = p
+	p.ProfileName = rename
 	delete(GlobalConfig.Profiles, name)
 	if GlobalConfig.CurrentProfile == name {
 		GlobalConfig.CurrentProfile = rename
@@ -176,6 +180,9 @@ func Load() {
 	Config = GlobalConfig.Profiles[GlobalConfig.CurrentProfile]
 	if Config == nil {
 		SelectProfile("default")
+	}
+	if Config.ProfileName == "" {
+		Config.ProfileName = GlobalConfig.CurrentProfile
 	}
 }
 

--- a/pkg/model/column_formatters.go
+++ b/pkg/model/column_formatters.go
@@ -43,4 +43,5 @@ func init() {
 	RegisterColumnFormatter("", nil)
 	RegisterColumnFormatter("ts", print.TimestampFormatter)
 	RegisterColumnFormatter("relative_ts", print.RelativeTimestampFormatter)
+	RegisterColumnFormatter("bytes", print.BytesFormatter)
 }

--- a/pkg/print/formatters.go
+++ b/pkg/print/formatters.go
@@ -27,6 +27,12 @@ var (
 	formatterLocation *time.Location
 )
 
+const (
+	kb = float64(int64(1) << 10)
+	mb = float64(int64(1) << 20)
+	gb = float64(int64(1) << 30)
+)
+
 type Formatters map[string]Formatter
 
 func (f Formatters) Format(columnName string, n *jnode.Node) string {
@@ -90,4 +96,17 @@ func RelativeTimestampFormatter(n *jnode.Node, columnName string) string {
 		return prefix + d.Round(time.Second).String()
 	}
 	return s
+}
+
+func BytesFormatter(n *jnode.Node, columnName string) string {
+	val := n.Path(columnName).AsFloat()
+	switch {
+	case val >= gb:
+		return fmt.Sprintf("%.1fG", val/gb)
+	case val >= mb:
+		return fmt.Sprintf("%.1fM", val/mb)
+	case val >= kb:
+		return fmt.Sprintf("%.1fK", val/kb)
+	}
+	return n.Path(columnName).AsText()
 }

--- a/pkg/print/formatters_test.go
+++ b/pkg/print/formatters_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/soluble-ai/go-jnode"
 )
 
-func TestFormatters(t *testing.T) {
+func TestTimestampFormatters(t *testing.T) {
 	now := time.Date(2020, 5, 11, 10, 5, 45, 0, time.UTC)
 	formatterNow = &now
 	formatterLocation = time.FixedZone("test", -8*60*60)
@@ -31,5 +31,25 @@ func TestFormatters(t *testing.T) {
 	}
 	if s := RelativeTimestampFormatter(n, "ts"); s != "2d22h47m12s" {
 		t.Error("relative ts wrong", n, s)
+	}
+}
+
+var bytesTestCases = []struct {
+	value    int
+	expected string
+}{
+	{10, "10"},
+	{1536, "1.5K"},
+	{1258291, "1.2M"},
+	{2684354560, "2.5G"},
+}
+
+func TestBytesFormatter(t *testing.T) {
+	for _, c := range bytesTestCases {
+		n := jnode.NewObjectNode().Put("n", c.value)
+		s := BytesFormatter(n, "n")
+		if s != c.expected {
+			t.Error(c.value, c.expected, s)
+		}
 	}
 }


### PR DESCRIPTION
* Move agent list command to model

* Add bytes formatter, and use it to report agent memory usage

* config show now includes profile name

* config set-profile only prints the new profile

* job get requires --job-id