### PR TITLE
Cleanup iac-scan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,5 +27,6 @@ require (
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 // indirect
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.2.4
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -40,6 +41,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
@@ -51,6 +53,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -69,6 +72,7 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jarcoal/httpmock v1.0.6 h1:e81vOSexXU3mJuJ4l//geOmKIt+Vkxerk1feQBC8D0g=
 github.com/jarcoal/httpmock v1.0.6/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
@@ -80,9 +84,12 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kyokomi/emoji v2.1.0+incompatible h1:+DYU2RgpI6OHG4oQkM5KlqD3Wd3UPEsX8jamTo1Mp6o=
 github.com/kyokomi/emoji v2.1.0+incompatible/go.mod h1:mZ6aGCD7yk8j6QY6KICwnZ2pxoszVseX1DNoGtU2tBA=
@@ -124,6 +131,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
@@ -154,6 +162,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -185,6 +194,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -217,7 +227,9 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -226,12 +238,14 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -55,6 +55,7 @@ type Interface interface {
 	Delete(path string, options ...Option) (*jnode.Node, error)
 	XCPPost(orgID string, module string, files []string, values map[string]string, options ...Option) error
 	GetClient() *resty.Client
+	GetOrganization() string
 }
 
 type clientT struct {
@@ -201,4 +202,8 @@ func (c *clientT) XCPPost(orgID string, module string, files []string, values ma
 	req = applyOptions(req, options)
 	_, err := req.Post(fmt.Sprintf("/api/v1/xcp/%s/data", module))
 	return err
+}
+
+func (c *clientT) GetOrganization() string {
+	return c.Organization
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/soluble-ai/go-jnode"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var GlobalConfig = &struct {

--- a/pkg/download/options.go
+++ b/pkg/download/options.go
@@ -1,0 +1,12 @@
+package download
+
+import "net/http"
+
+type DownloadOption func(req *http.Request) error
+
+func WithBearerToken(token string) DownloadOption {
+	return func(req *http.Request) error {
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+}

--- a/pkg/iacinventory/github_repo.go
+++ b/pkg/iacinventory/github_repo.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v32/github"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"golang.org/x/oauth2"
 )

--- a/pkg/iacscan/iacscan.go
+++ b/pkg/iacscan/iacscan.go
@@ -1,11 +1,47 @@
 package iacscan
 
-import "github.com/soluble-ai/go-jnode"
+import (
+	"fmt"
+
+	"github.com/soluble-ai/go-jnode"
+	"github.com/soluble-ai/soluble-cli/pkg/client"
+)
 
 type IacScanner interface {
-	Run() (*jnode.Node, error)
+	Run() (*Result, error)
 }
 
-func New(scannerType interface{}) IacScanner {
-	return scannerType.(IacScanner)
+type Result struct {
+	N            *jnode.Node
+	PrintPath    []string
+	PrintColumns []string
+}
+
+type Config struct {
+	ReportEnabled bool
+	Organizaton   string
+	APIClient     client.Interface
+	Directory     string
+	ScannerType   string
+}
+
+func New(config Config) (IacScanner, error) {
+	var scanner IacScanner
+	switch config.ScannerType {
+	case "terrascan":
+		scanner = &StockTerrascan{
+			directory: config.Directory,
+			apiClient: config.APIClient,
+		}
+	default:
+		return nil, fmt.Errorf("unknown scanner %s", config.ScannerType)
+	}
+	if config.ReportEnabled {
+		scanner = &Reporter{
+			Config:  config,
+			scanner: scanner,
+			module:  config.ScannerType,
+		}
+	}
+	return scanner, nil
 }

--- a/pkg/iacscan/report.go
+++ b/pkg/iacscan/report.go
@@ -1,0 +1,33 @@
+package iacscan
+
+import (
+	"bytes"
+
+	"github.com/soluble-ai/soluble-cli/pkg/client"
+	"github.com/soluble-ai/soluble-cli/pkg/log"
+)
+
+type Reporter struct {
+	Config
+	scanner IacScanner
+	module  string
+}
+
+func (r *Reporter) Run() (*Result, error) {
+	result, err := r.scanner.Run()
+	if err != nil {
+		return nil, err
+	}
+	rr := bytes.NewReader([]byte(result.N.String()))
+	log.Infof("Uploading iac scan results")
+	values := map[string]string{
+		"directory":   r.Directory,
+		"scannerType": r.ScannerType,
+	}
+	err = r.APIClient.XCPPost(r.Organizaton, r.module, nil, values,
+		client.XCPWithCIEnv, client.XCPWithReader("results_json", "results.json", rr))
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/iacscan/stock_terrascan.go
+++ b/pkg/iacscan/stock_terrascan.go
@@ -1,27 +1,18 @@
 package iacscan
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/soluble-ai/go-jnode"
 	"github.com/soluble-ai/soluble-cli/pkg/client"
-	"github.com/soluble-ai/soluble-cli/pkg/config"
 	"github.com/soluble-ai/soluble-cli/pkg/download"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
-	"github.com/soluble-ai/soluble-cli/pkg/options"
-	"gopkg.in/yaml.v2"
 )
 
 var _ IacScanner = &StockTerrascan{}
-var supportedTypes [4]string = [4]string{"aws", "gcp", "azure", "k8s"}
 
 const (
 	policyZip = "rego-policies.zip"
@@ -29,166 +20,58 @@ const (
 )
 
 type StockTerrascan struct {
-	Directory  string
-	policyPath string
-	Report     bool
+	directory  string
 	apiClient  client.Interface
+	policyPath string
 }
 
-func (t *StockTerrascan) Run() (*jnode.Node, error) {
-	opts := options.ClientOpts{}
-	t.apiClient = opts.GetAPIClient()
-
+func (t *StockTerrascan) Run() (*Result, error) {
 	m := download.NewManager()
 	d, err := m.InstallGithubRelease("accurics", "terrascan", "")
 	if err != nil {
 		return nil, err
 	}
 
-	policiesDir := filepath.Join(config.ConfigDir, "policies")
-	if err = t.downloadPolicies(policiesDir); err != nil {
+	if err = t.downloadPolicies(); err != nil {
 		return nil, err
 	}
 
+	log.Infof("Running {info:terrascan} -d %s", t.directory)
 	program := filepath.Join(d.Dir, "terrascan")
-	init := exec.Command(program, "init")
-	init.Stdout = os.Stderr
-	init.Stderr = os.Stderr
-	log.Infof("%s", init.Args)
-	if err = init.Run(); err != nil {
-		return nil, fmt.Errorf("terrascan init failed: %w", err)
-	}
-
-	v := []map[string]interface{}{}
-	for _, iacType := range supportedTypes {
-		scan := exec.Command(program, "scan", "-t", iacType, "-d", t.Directory, "-p", t.policyPath)
-		out := &bytes.Buffer{}
-		scan.Stderr = os.Stderr
-		scan.Stdout = out
-		scan.Stderr = os.Stderr
-		log.Infof("%s", scan.Args)
-		_ = scan.Run()
-
-		var output map[string]interface{}
-		if err = yaml.Unmarshal(out.Bytes(), &output); err != nil {
-			return nil, fmt.Errorf("could not parse terrascan output: %w", err)
-		}
-		v = append(v, output)
-	}
-
-	result := mergeViolationResults(v...)
-	err = t.uploadResults(opts.GetOrganization(), result)
+	// the -t argument is required but it only selects what policies are
+	// selected if the -p option isn't used.  Since we're using -p,
+	// we can pass any valid value.
+	scan := exec.Command(program, "scan", "-t", "aws", "-d", t.directory, "-p", t.policyPath, "-o", "json")
+	scan.Stderr = os.Stderr
+	scan.Stderr = os.Stderr
+	output, err := scan.Output()
 	if err != nil {
-		return jnode.FromMap(result), nil
+		ee, ok := err.(*exec.ExitError)
+		// terrascan exits with exit code 3 if violations were found
+		if !ok || ee.ExitCode() != 3 {
+			return nil, err
+		}
 	}
-
-	return jnode.FromMap(result), nil
+	n, err := jnode.FromJSON(output)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{
+		N:            n,
+		PrintPath:    []string{"results", "violations"},
+		PrintColumns: []string{"category", "severity", "file", "line", "rule_id", "description"},
+	}, nil
 }
 
-func (t *StockTerrascan) downloadPolicies(downloadDir string) error {
-	policyPath := filepath.Join(downloadDir, rulesPath)
-	_, err := os.Stat(policyPath)
-
-	// TODO: Check the version or tag to determine the download rather than checking directory
-	if os.IsNotExist(err) {
-		// Download the policies from the API server to the specified policyPath
-		path := fmt.Sprintf("org/{org}/opa/%s", policyZip)
-		t.apiClient.GetClient().SetOutputDirectory(downloadDir)
-		_, err := t.apiClient.Get(path, func(req *resty.Request) {
-			req.SetOutput(policyZip)
-		})
-		if err != nil {
-			return err
-		}
-
-		policiesZipPath := filepath.Join(downloadDir, policyZip)
-		cmd := exec.Command("unzip", "-o", "-d", downloadDir, policiesZipPath)
-		if err = cmd.Run(); err != nil {
-			return err
-		}
-
-		// remove the zip file
-		_ = os.Remove(policiesZipPath)
+func (t *StockTerrascan) downloadPolicies() error {
+	m := download.NewManager()
+	url := fmt.Sprintf("%s/api/v1/org/%s/opa/%s", t.apiClient.GetClient().HostURL, t.apiClient.GetOrganization(),
+		policyZip)
+	d, err :=
+		m.Install("terrascan-policies", "latest", url, download.WithBearerToken(t.apiClient.GetClient().Token))
+	if err != nil {
+		return err
 	}
-
-	t.policyPath = policyPath
+	t.policyPath = filepath.Join(d.Dir, rulesPath)
 	return nil
-}
-
-func (t *StockTerrascan) uploadResults(org string, result map[string]interface{}) error {
-	if t.Report {
-		file, err := os.Create("results.json")
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-
-		j, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return err
-		}
-
-		w := bufio.NewWriter(file)
-		_, err = w.WriteString(string(j))
-		if err != nil {
-			return err
-		}
-		w.Flush()
-
-		dir, _ := os.Getwd()
-		pathToFile := filepath.Join(dir, file.Name())
-		files := []string{pathToFile}
-
-		ciOptions := []client.Option{client.XCPWithCIEnv}
-		err = t.apiClient.XCPPost(org, "terrascan", files, nil, ciOptions...)
-		if err != nil {
-			return err
-		}
-		// remove the results file
-		_ = os.Remove(pathToFile)
-	}
-	return nil
-}
-
-func mergeViolationResults(maps ...map[string]interface{}) map[string]interface{} {
-	var lowCount, highCount, mediumCount, totalCount int
-	violationsStats := make(map[string]int)
-
-	var violations []map[string]string
-	for _, m := range maps {
-		for _, v := range m["results"].(map[interface{}]interface{})["violations"].([]interface{}) {
-			switch severity := v.(map[interface{}]interface{})["severity"].(string); strings.ToLower(severity) {
-			case "high":
-				highCount++
-			case "low":
-				lowCount++
-			case "medium":
-				mediumCount++
-			}
-
-			totalCount++
-
-			vs := make(map[string]string)
-			for key, value := range v.(map[interface{}]interface{}) {
-				strKey := fmt.Sprintf("%v", key)
-				strValue := fmt.Sprintf("%v", value)
-
-				vs[strKey] = strValue
-			}
-			violations = append(violations, vs)
-		}
-	}
-
-	violationsStats["total"] = totalCount
-	violationsStats["low"] = lowCount
-	violationsStats["medium"] = mediumCount
-	violationsStats["high"] = highCount
-
-	output := make(map[string]interface{})
-	output["count"] = violationsStats
-	output["violations"] = violations
-
-	result := make(map[string]interface{})
-	result["results"] = output
-	return result
 }

--- a/pkg/print/yaml.go
+++ b/pkg/print/yaml.go
@@ -19,7 +19,7 @@ import (
 	"io"
 
 	"github.com/soluble-ai/go-jnode"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type YAMLPrinter struct{}


### PR DESCRIPTION
* Fix download latest from github installing again if latest is unchanged

* Support download latest from URL

* Support download options (including bearer token)

* Use download manager to download terrascan policies

* Upgrade to yaml.v3 to avoid map[interface{}]interface{} issue in future

* Refactor iac-scan reporting

* Don't run terrascan multiple times

* Better printing of terrascan results

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>