### PR TITLE
Improve help

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -32,6 +32,7 @@ func pingClusterCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "ping",
 		Short: "Send a ping message the cluster operator",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterID := opts.GetClusterID()
 			path := fmt.Sprintf("org/{org}/clusters/%s/ping", clusterID)
@@ -74,6 +75,7 @@ func deployAgentCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "deploy",
 		Short: "Download the kubenertes resources to deploy the agent in a cluster",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiClient := opts.GetAPIClient()
 			var tail string

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -41,6 +41,7 @@ func profileCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "profile",
 		Short: "Display the user's Soluble profile",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiClient := opts.GetAPIClient()
 			result, err := apiClient.Get("/api/v1/users/profile")
@@ -65,6 +66,7 @@ func printTokenCmd() *cobra.Command {
 		Long: `Print the access token, e.g. for use with curl:
 		
 curl -H “Authorization: Bearer $(soluble print-access-token)” ...`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if config.Config.APIToken == "" {
 				return fmt.Errorf("not authenticated, use login to authenticate")
@@ -85,6 +87,7 @@ func setAccessTokenCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "set-access-token",
 		Short: "Add an access token",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config.Config.APIToken = accessToken
 			cfg := opts.GetAPIClientConfig()
@@ -113,6 +116,7 @@ func setOrgCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "set-org",
 		Short: "Change the user's current organization",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			body := jnode.NewObjectNode()
 			body.Put("orgId", opts.Organization)

--- a/cmd/aws/aws.go
+++ b/cmd/aws/aws.go
@@ -37,6 +37,7 @@ func setupCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "get-setup",
 		Short: "Return the aws CLI commands to create a role for Soluble to use",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiClient := opts.GetAPIClient()
 			response, err := apiClient.GetClient().R().

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -75,6 +75,7 @@ func setProfileCmd() *cobra.Command {
 		Use:     "set-profile",
 		Aliases: []string{"new-profile"},
 		Short:   "Set the current profile (or create a new one)",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config.SelectProfile(name)
 			if copyFrom != "" {
@@ -102,6 +103,7 @@ func updateProfileCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "update-profile",
 		Short: "Rename or delete a profile",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" {
 				name = config.GlobalConfig.CurrentProfile
@@ -138,6 +140,7 @@ func listProfilesCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "list-profiles",
 		Short: "Lists the CLI profiles",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			opts.PrintResult(getProfiles(nil))
 		},
@@ -166,6 +169,7 @@ func showConfigCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "show",
 		Short: "Show the configuration of the CLI",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			opts.PrintConfig()
 		},

--- a/cmd/downloadcmd/downloadcmd.go
+++ b/cmd/downloadcmd/downloadcmd.go
@@ -26,6 +26,7 @@ func listCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List downloaded components",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			m := download.NewManager()
 			result := m.List()

--- a/cmd/iacinventorycmd/iacinventorycmd.go
+++ b/cmd/iacinventorycmd/iacinventorycmd.go
@@ -12,6 +12,7 @@ func Command() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "iac-inventory",
 		Short: "Look for infrastructure-as-code and optionally send the inventory to Soluble",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.RunTool(tool)
 		},

--- a/cmd/iacscan/iacscan.go
+++ b/cmd/iacscan/iacscan.go
@@ -19,6 +19,7 @@ func Command() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "iac-scan",
 		Short: "Run an Infrastructure-as-code scanner",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scannerType == "" {
 				prompt := promptui.Select{

--- a/cmd/imagescan/imagescan.go
+++ b/cmd/imagescan/imagescan.go
@@ -12,6 +12,7 @@ func Command() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "image-scan",
 		Short: "Scan a container image and optionally upload the results",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.RunTool(tool)
 		},

--- a/cmd/model/model.go
+++ b/cmd/model/model.go
@@ -45,6 +45,7 @@ func listModels() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List API models",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			result := jnode.NewObjectNode()
 			a := result.PutArray("models")
@@ -66,6 +67,7 @@ func addModel() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "add-git-location",
 		Short: "Add an API model from git",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !strings.HasPrefix(url, "git@") {
 				return fmt.Errorf("only git@... urls are supported")

--- a/cmd/postcmd/postcmd.go
+++ b/cmd/postcmd/postcmd.go
@@ -18,6 +18,7 @@ func Command() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "post",
 		Short: "Send data to soluble",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var options []client.Option
 			if withEnv {

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -44,6 +44,7 @@ func listCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List available queries",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := opts.GetAPIClient().Get("/api/v1/org/{org}/queries")
 			if err != nil {
@@ -68,6 +69,7 @@ func listParametersCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "list-parameters",
 		Short: "List the parameters of a query",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := opts.GetAPIClient().Get("/api/v1/org/{org}/queries")
 			if err != nil {
@@ -101,6 +103,7 @@ func runCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "run",
 		Short: "Run a query",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/org/{org}/queries/%s", queryName)
 			if textSearch != "" {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -72,6 +72,7 @@ func Command() *cobra.Command {
 			}
 			return nil
 		},
+		Version: v.Version,
 	}
 
 	rootCmd.PersistentFlags().StringVar(&profile, "profile", "", "Use this configuration profile (see 'config list-profiles')")

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -24,6 +24,7 @@ func Command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Shows soluble CLI version",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			colorize.Colorize("version: {info:%s}\nbuilt:   %s\n", v.Version, v.BuildTime)
 		},

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/soluble-ai/go-jnode v0.1.11
 	github.com/spf13/afero v1.4.1
 	github.com/spf13/cobra v1.0.0
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1 // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be

--- a/pkg/model/git_source.go
+++ b/pkg/model/git_source.go
@@ -54,14 +54,14 @@ func GetGitSource(url string) (Source, error) {
 	switch {
 	case gitConfig == nil:
 		// repo doesn't exist, clone the repo
-		log.Infof("Cloning {primary:%s} to {info:%s}", url, dir)
+		log.Debugf("Cloning {primary:%s} to {info:%s}", url, dir)
 		err := git("clone", "--depth", "1", url, dir).Run()
 		if err != nil {
 			return nil, err
 		}
 	case fetchHead == nil || time.Now().After(fetchHead.ModTime().Add(5*time.Minute)):
 		// repo exists, and we haven't fetched it in a while
-		log.Infof("Updating git model repository {primary:%s}", dir)
+		log.Debugf("Updating git model repository {primary:%s}", dir)
 		c := git("fetch", "-q", "--depth", "1")
 		c.Dir = dir
 		done := make(chan error)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -101,6 +101,7 @@ func (cm *CommandModel) GetCommand() Command {
 	c := &cobra.Command{
 		Use:   cm.Name,
 		Short: cm.Short,
+		Args:  cobra.NoArgs,
 	}
 	if cm.Use != nil {
 		c.Use = *cm.Use

--- a/pkg/options/base.go
+++ b/pkg/options/base.go
@@ -15,10 +15,45 @@
 package options
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
 type Interface interface {
 	Register(cmd *cobra.Command)
 	SetContextValues(context map[string]string)
+}
+
+type HiddenOptionsGroup struct {
+	Use         string
+	Description string
+	OptionNames []string
+}
+
+func AddHiddenOptionsGroup(cmd *cobra.Command, group *HiddenOptionsGroup) {
+	for _, name := range group.OptionNames {
+		_ = cmd.Flags().MarkHidden(name)
+	}
+	help := &cobra.Command{
+		Use:   group.Use,
+		Short: fmt.Sprintf("Show help for flags that %s", group.Description),
+		Long:  fmt.Sprintf("These flags %s", group.Description),
+	}
+	for _, name := range group.OptionNames {
+		flag := cmd.Flags().Lookup(name)
+		if flag != nil {
+			copy := *flag
+			copy.Hidden = false
+			help.Flags().AddFlag(&copy)
+		}
+	}
+	// suppress the default help flag
+	help.Flags().BoolP("help", "h", false, "Display help")
+	_ = help.Flags().MarkHidden("help")
+	help.SetHelpTemplate(`{{.Long}}
+
+{{.LocalFlags.FlagUsages}}
+`)
+	cmd.AddCommand(help)
 }

--- a/pkg/options/client.go
+++ b/pkg/options/client.go
@@ -43,8 +43,16 @@ func (opts *ClientOpts) Register(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&opts.Headers, "header", nil, "Set custom headers on request")
 	if !opts.AuthNotRequired {
 		cmd.Flags().StringVar(&opts.Organization, "organization", "", "The organization to use.")
-		cmd.Flags().StringVar(&opts.APIToken, "token", "", "The authentication token (read from profile by default)")
+		cmd.Flags().StringVar(&opts.APIToken, "api-token", "", "The authentication token (read from profile by default)")
 	}
+	AddHiddenOptionsGroup(cmd, &HiddenOptionsGroup{
+		Use:         "show-client-options",
+		Description: "control how the CLI connects to Soluble",
+		OptionNames: []string{
+			"api-server", "disable-tls-verify", "timeout", "retry", "header", "organization",
+			"api-token", "retry-wait",
+		},
+	})
 }
 
 func (opts *ClientOpts) GetAPIClientConfig() *client.Config {

--- a/pkg/options/print.go
+++ b/pkg/options/print.go
@@ -75,6 +75,13 @@ reverse numeric sort.`)
 			`When printing diffs, the number of lines to print before and
 after a a diff.`)
 	}
+	AddHiddenOptionsGroup(cmd, &HiddenOptionsGroup{
+		Use:         "show-print-options",
+		Description: "control how results are printed",
+		OptionNames: []string{
+			"format", "no-headers", "wide", "sort-by", "filter", "print-limit", "diff-context",
+		},
+	})
 }
 
 func (p *PrintOpts) GetPrinter() print.Interface {

--- a/pkg/tools/toolopts.go
+++ b/pkg/tools/toolopts.go
@@ -25,6 +25,8 @@ type ToolOpts struct {
 var _ options.Interface = &ToolOpts{}
 
 func (o *ToolOpts) Register(c *cobra.Command) {
+	// set this now so help shows up, it will be corrected before we print anything
+	o.Path = []string{}
 	o.PrintClientOpts.Register(c)
 	flags := c.Flags()
 	flags.BoolVar(&o.UploadEnabled, "upload", false, "Upload report to Soluble")


### PR DESCRIPTION
* Hide common clent or printing options, and add show-client-options
and show-print-options help commands to display details

* Use cobra.NoArgs for all commands that don't take any arguments

* Change the flag name --token to --api-token

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>