### PR TITLE
Rework help

### DIFF
--- a/cmd/root/help.go
+++ b/cmd/root/help.go
@@ -1,0 +1,99 @@
+package root
+
+import (
+	"strings"
+
+	"github.com/soluble-ai/soluble-cli/pkg/options"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func setupHelp(rootCmd *cobra.Command) {
+	rootCmd.SetHelpCommand(helpCommand(rootCmd))
+	rootCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+{{.NameAndAliases}}{{end}}{{if .HasExample}}
+  
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+  
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
+
+{{- if (and (or .Runnable .IsAdditionalHelpTopicCommand) .HasAvailableLocalFlags) }}
+  
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
+{{- if (and .HasAvailableInheritedFlags .Annotations.ShowInheritedFlags) }}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+  
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+{{- if (and .Runnable (not .Annotations.ShowInheritedFlags)) }}
+
+Some options have been hidden, use "{{ helpPath $ }} -a" to display all options{{end}}
+
+`)
+	globalOptionsHelp := &cobra.Command{
+		Use:  "help-global-options",
+		Long: "Global options",
+		Annotations: map[string]string{
+			"ShowInheritedFlags": "1",
+		},
+	}
+	globalOptionsHelp.SetHelpTemplate(`{{.Long}}
+
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+`)
+	rootCmd.AddCommand(options.GetClientOptionsGroupHelpCommand(),
+		options.GetPrintOptionsGroupHelpCommand(),
+		globalOptionsHelp)
+}
+
+func helpCommand(rootCmd *cobra.Command) *cobra.Command {
+	var (
+		allOptions bool
+	)
+	c := &cobra.Command{
+		Use:   "help",
+		Short: "Help about any command",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, _, err := rootCmd.Find(args)
+			if err != nil {
+				return err
+			}
+			if target.Annotations == nil {
+				target.Annotations = map[string]string{}
+			}
+			if allOptions {
+				target.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+					flag.Hidden = false
+				})
+				target.Annotations["ShowInheritedFlags"] = "1"
+			}
+			return target.Help()
+		},
+		Annotations: map[string]string{"ShowInheritedFlags": ""},
+	}
+	flags := c.Flags()
+	flags.BoolVarP(&allOptions, "all-options", "a", false, "Show help for all options")
+	return c
+}
+
+func init() {
+	cobra.AddTemplateFunc("helpPath", func(cmd *cobra.Command) string {
+		path := strings.Split(cmd.CommandPath(), " ")
+		helpPath := append([]string{path[0]}, "help")
+		if len(path) > 1 {
+			helpPath = append(helpPath, path[1:]...)
+		}
+		return strings.Join(helpPath, " ")
+	})
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -105,12 +105,12 @@ func Command() *cobra.Command {
 	for _, model := range model.Models {
 		mergeCommands(rootCmd, model.Command.GetCommand().GetCobraCommand(), model)
 	}
-
+	setupHelp(rootCmd)
 	return rootCmd
 }
 
 func addBuiltinCommands(rootCmd *cobra.Command) {
-	commands := []*cobra.Command{
+	rootCmd.AddCommand(
 		auth.Command(),
 		agent.Command(),
 		aws.Command(),
@@ -124,10 +124,7 @@ func addBuiltinCommands(rootCmd *cobra.Command) {
 		imagescan.Command(),
 		iacinventorycmd.Command(),
 		logincmd.Command(),
-	}
-	for _, c := range commands {
-		rootCmd.AddCommand(c)
-	}
+	)
 }
 
 func loadModels() {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/soluble-ai/go-jnode v0.1.11
 	github.com/spf13/afero v1.4.1
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/pkg/options/base.go
+++ b/pkg/options/base.go
@@ -15,45 +15,10 @@
 package options
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 type Interface interface {
 	Register(cmd *cobra.Command)
 	SetContextValues(context map[string]string)
-}
-
-type HiddenOptionsGroup struct {
-	Use         string
-	Description string
-	OptionNames []string
-}
-
-func AddHiddenOptionsGroup(cmd *cobra.Command, group *HiddenOptionsGroup) {
-	for _, name := range group.OptionNames {
-		_ = cmd.Flags().MarkHidden(name)
-	}
-	help := &cobra.Command{
-		Use:   group.Use,
-		Short: fmt.Sprintf("Show help for flags that %s", group.Description),
-		Long:  fmt.Sprintf("These flags %s", group.Description),
-	}
-	for _, name := range group.OptionNames {
-		flag := cmd.Flags().Lookup(name)
-		if flag != nil {
-			copy := *flag
-			copy.Hidden = false
-			help.Flags().AddFlag(&copy)
-		}
-	}
-	// suppress the default help flag
-	help.Flags().BoolP("help", "h", false, "Display help")
-	_ = help.Flags().MarkHidden("help")
-	help.SetHelpTemplate(`{{.Long}}
-
-{{.LocalFlags.FlagUsages}}
-`)
-	cmd.AddCommand(help)
 }

--- a/pkg/options/group.go
+++ b/pkg/options/group.go
@@ -1,0 +1,40 @@
+package options
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type HiddenOptionsGroup struct {
+	Name            string
+	Long            string
+	Example         string
+	CreateFlagsFunc func(*pflag.FlagSet)
+}
+
+func (group *HiddenOptionsGroup) Register(cmd *cobra.Command) {
+	flags := &pflag.FlagSet{}
+	group.CreateFlagsFunc(flags)
+	flags.VisitAll(func(f *pflag.Flag) {
+		f.Hidden = true
+		cmd.Flags().AddFlag(f)
+	})
+}
+
+func (group *HiddenOptionsGroup) GetHelpCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:     fmt.Sprintf("help-%s", group.Name),
+		Long:    group.Long,
+		Example: group.Example,
+	}
+	group.CreateFlagsFunc(c.Flags())
+	c.SetHelpTemplate(`{{.Long}}
+
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{ if .HasExample }}
+{{.Example}}
+{{end}}
+`)
+	return c
+}


### PR DESCRIPTION
* Hide global, client, and print options by default

* Add "help -a" command to display all options

* Add help topics for client, global, and print options