### PR TITLE
Allow local execution instead of docker

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,7 @@ github.com/hashicorp/hcl/v2 v2.7.1 h1:eZWfKEO93WyE4OnZSD5LVy70YHDV/mmQ49gpKDLpDV
 github.com/hashicorp/hcl/v2 v2.7.1/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hcl/v2 v2.7.2 h1:SpE9BfBb/nFxXRZvvKINKeQiGpyj6d0hhgXVqEtLGD4=
 github.com/hashicorp/hcl/v2 v2.7.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
+github.com/hashicorp/hcl/v2 v2.8.0 h1:iHLEAsNDp3N2MtqroP1wf0nF/zB2+McHN5YCzwqIm80=
 github.com/hashicorp/hcl/v2 v2.8.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -217,6 +218,7 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
 github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
+github.com/spf13/afero v1.5.0 h1:8Wb647pxgVlypPIdcDlffCLCHCElBZ1sCF6i85qNvRw=
 github.com/spf13/afero v1.5.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
@@ -237,6 +239,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/gjson v1.6.3 h1:aHoiiem0dr7GHkW001T1SMTJ7X5PvyekH5WX0whWGnI=
 github.com/tidwall/gjson v1.6.3/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
+github.com/tidwall/gjson v1.6.4 h1:JKsCsJqRVFz8eYCsQ5E/ANRbK6CanAtA9IUvGsXklyo=
 github.com/tidwall/gjson v1.6.4/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -30,6 +30,7 @@ type Download struct {
 	APIServerArtifact string
 	Dir               string
 	InstallTime       time.Time
+	OverrideExe       string
 }
 
 type DownloadMeta struct {
@@ -365,9 +366,19 @@ func (d *Download) Install(file string) error {
 	return archive.Do(unpack, file, d.Dir, nil)
 }
 
+func (d *Download) GetExePath(path string) string {
+	if d.OverrideExe != "" {
+		return d.OverrideExe
+	}
+	return filepath.Join(d.Dir, path)
+}
+
 func (d *Download) installExecutable(src afero.File, fs afero.Fs, options *archive.Options) error {
 	// just copy the file
 	name := d.Name
+	if owner, repo := parseGithubRepo(d.URL); owner != "" {
+		name = repo
+	}
 	if strings.HasSuffix(src.Name(), ".exe") {
 		name = fmt.Sprintf("%s.exe", name)
 	}

--- a/pkg/tools/cfn-python-lint/cfn-python-lint.go
+++ b/pkg/tools/cfn-python-lint/cfn-python-lint.go
@@ -32,12 +32,10 @@ func (t *Tool) Run() (*tools.Result, error) {
 		return nil, err
 	}
 	d, _ := t.RunDocker(&tools.DockerTool{
-		Name:  "cfn-python-lint",
-		Image: "gcr.io/soluble-repo/soluble-cfn-lint:latest",
-		DockerArgs: []string{
-			"--volume", fmt.Sprintf("%s:%s:ro", t.GetDirectory(), "/data"),
-		},
-		Args: files,
+		Name:      "cfn-python-lint",
+		Image:     "gcr.io/soluble-repo/soluble-cfn-lint:latest",
+		Directory: t.GetDirectory(),
+		Args:      append([]string{"-f", "json"}, files...),
 	})
 	results, err := jnode.FromJSON(d)
 	if err != nil {
@@ -67,13 +65,11 @@ func (t *Tool) findCloudformationFiles() ([]string, error) {
 					return nil, fmt.Errorf("template file %s must be relative to --directory", f)
 				}
 			}
-			files = append(files, fmt.Sprintf("/data/%s", rf))
+			files = append(files, rf)
 		}
 	} else {
 		m := inventory.Do(t.GetDirectory())
-		for _, f := range m.CloudformationFiles.Values() {
-			files = append(files, fmt.Sprintf("/data/%s", f))
-		}
+		files = m.CloudformationFiles.Values()
 	}
 	return files, nil
 }

--- a/pkg/tools/checkov/checkov.go
+++ b/pkg/tools/checkov/checkov.go
@@ -1,7 +1,6 @@
 package checkov
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/soluble-ai/go-jnode"
@@ -24,13 +23,11 @@ func (t *Tool) SetDirectory(dir string) {
 
 func (t *Tool) Run() (*tools.Result, error) {
 	dat, err := t.RunDocker(&tools.DockerTool{
-		Name:  "checkov",
-		Image: "gcr.io/soluble-repo/checkov:latest",
-		DockerArgs: []string{
-			"-v", fmt.Sprintf("%s:%s", t.GetDirectory(), "/tf"),
-		},
+		Name:      "checkov",
+		Image:     "gcr.io/soluble-repo/checkov:latest",
+		Directory: t.GetDirectory(),
 		Args: []string{
-			"-d", "/tf", "-o", "json", "-s",
+			"-d", ".", "-o", "json", "-s",
 		},
 	})
 	if err != nil {

--- a/pkg/tools/docker.go
+++ b/pkg/tools/docker.go
@@ -12,6 +12,7 @@ import (
 type DockerTool struct {
 	Name       string
 	Image      string
+	Directory  string
 	DockerArgs []string
 	Args       []string
 }
@@ -46,7 +47,12 @@ func (t *DockerTool) run() ([]byte, error) {
 	if err := pull.Run(); err != nil {
 		log.Warnf("docker pull {primary:%s} failed: {warning:%s}", t.Image, err)
 	}
-	args := append([]string{"run", "--rm"}, t.DockerArgs...)
+	args := []string{"run", "--rm"}
+	if t.Directory != "" {
+		args = append(args, "-v", fmt.Sprintf("%s:/src", t.Directory),
+			"-w", "/src")
+	}
+	args = append(args, t.DockerArgs...)
 	args = append(args, t.Image)
 	args = append(args, t.Args...)
 	run := exec.Command("docker", args...)

--- a/pkg/tools/iacinventory/github.go
+++ b/pkg/tools/iacinventory/github.go
@@ -32,6 +32,7 @@ func (g *Github) Name() string {
 }
 
 func (g *Github) Register(c *cobra.Command) {
+	g.Internal = true
 	g.ToolOpts.Register(c)
 	flags := c.Flags()
 	flags.StringVar(&g.User, "gh-username", "", "Github Username")

--- a/pkg/tools/iacinventory/local.go
+++ b/pkg/tools/iacinventory/local.go
@@ -18,6 +18,11 @@ func (t *Local) Name() string {
 	return "local-inventory"
 }
 
+func (t *Local) Register(cmd *cobra.Command) {
+	t.Internal = true
+	t.DirectoryBasedToolOpts.Register(cmd)
+}
+
 func (t *Local) CommandTemplate() *cobra.Command {
 	return &cobra.Command{
 		Use:   "local",

--- a/pkg/tools/secrets/secrets.go
+++ b/pkg/tools/secrets/secrets.go
@@ -1,7 +1,6 @@
 package secrets
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/soluble-ai/go-jnode"
@@ -20,11 +19,9 @@ func (t *Tool) Name() string {
 
 func (t *Tool) Run() (*tools.Result, error) {
 	d, _ := t.RunDocker(&tools.DockerTool{
-		Name:  "soluble-secrets",
-		Image: "gcr.io/soluble-repo/soluble-secrets:latest",
-		DockerArgs: []string{
-			"--volume", fmt.Sprintf("%s:%s:ro", t.GetDirectory(), "/repo"),
-		},
+		Name:      "soluble-secrets",
+		Image:     "gcr.io/soluble-repo/soluble-secrets:latest",
+		Directory: t.GetDirectory(),
 	})
 	results, err := jnode.FromJSON(d)
 	if err != nil {

--- a/pkg/tools/terrascan/terrascan.go
+++ b/pkg/tools/terrascan/terrascan.go
@@ -59,13 +59,13 @@ func (t *Tool) Run() (*tools.Result, error) {
 		return nil, err
 	}
 	result := &tools.Result{
-		Data:      n,
-		Directory: t.GetDirectory(),
-		Values: map[string]string{
-			"TERRASCAN_VERSION": d.Version,
-		},
+		Data:         n,
+		Directory:    t.GetDirectory(),
 		PrintPath:    []string{"results", "violations"},
 		PrintColumns: []string{"category", "severity", "file", "line", "rule_id", "description"},
+	}
+	if d.Version != "" {
+		result.AddValue("TERRASCAN_VERSION", d.Version)
 	}
 	for _, v := range n.Path("results").Path("violations").Elements() {
 		file := v.Path("file").AsText()

--- a/pkg/tools/tfsec/tfsec.go
+++ b/pkg/tools/tfsec/tfsec.go
@@ -48,7 +48,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 		},
 	}
 	// #nosec G204
-	c := exec.Command(filepath.Join(d.Dir, "tfsec-tfsec"), "-f", "json", ".")
+	c := exec.Command(d.GetExePath("tfsec-tfsec"), "-f", "json", ".")
 	c.Dir = t.GetDirectory()
 	c.Stderr = os.Stderr
 	log.Infof("Running {primary:%s}", strings.Join(c.Args, " "))

--- a/pkg/tools/trivy/trivy.go
+++ b/pkg/tools/trivy/trivy.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/soluble-ai/go-jnode"
@@ -54,8 +53,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	program := filepath.Join(d.Dir, "trivy")
-
+	program := d.GetExePath("trivy")
 	if t.ClearCache {
 		err := runCommand(program, "image", "--clear-cache")
 		if err != nil {


### PR DESCRIPTION
* Add flag --tool-path exe which runs exe instead of either the managed
downloaded tool or running the tool in docker

* The all command supports --tool-paths checkov=checkov

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>