### PR TITLE
Add --fail level=count flag to build-report

### DIFF
--- a/cmd/iacscan/exit_on_failures.go
+++ b/cmd/iacscan/exit_on_failures.go
@@ -1,0 +1,38 @@
+package iacscan
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/soluble-ai/go-jnode"
+	"github.com/soluble-ai/soluble-cli/pkg/exit"
+	"github.com/soluble-ai/soluble-cli/pkg/log"
+	"github.com/soluble-ai/soluble-cli/pkg/model"
+)
+
+func ExitOnFailures(command model.Command, result *jnode.Node) (*jnode.Node, error) {
+	findings := result.Path("findings")
+	thresholds, _ := command.GetCobraCommand().Flags().GetStringToString("fail")
+	for level, s := range thresholds {
+		value, err := strconv.Atoi(s)
+		if err != nil {
+			log.Warnf("Ignoring failure count {warning:%s} for level {warning:%s}", s, level)
+			continue
+		}
+		count := 0
+		for _, n := range findings.Elements() {
+			if strings.ToLower(n.Path("severity").AsText()) == level {
+				if n.Path("passed").AsText() != "true" {
+					count++
+				}
+			}
+		}
+		if count > value {
+			exit.Code = 2
+			exit.Message = fmt.Sprintf("Found {danger:%d failed %s} findings", count, level)
+			break
+		}
+	}
+	return result, nil
+}

--- a/pkg/model/disposition.go
+++ b/pkg/model/disposition.go
@@ -27,10 +27,12 @@ const (
 	ContextDisposition = ParameterDisposition("context")
 	// Read a file and post its content as the body
 	JSONFileBodyDisposition = ParameterDisposition("json_file_body")
+	// Do nothing with the flag
+	NOOPDisposition = ParameterDisposition("noop")
 )
 
 func (d ParameterDisposition) validate() error {
-	if d == "" || d == ContextDisposition || d == JSONFileBodyDisposition {
+	if d == "" || d == ContextDisposition || d == JSONFileBodyDisposition || d == NOOPDisposition {
 		return nil
 	}
 	return fmt.Errorf("invalid parameter disposition '%s' must be one of %s, %s",

--- a/resources/models/buildreport.hcl
+++ b/resources/models/buildreport.hcl
@@ -1,17 +1,25 @@
 api_prefix = "/api/v1"
 
-command "print_client" "build-report" {
-  short  = "Display information about the assessments generated during the current CI build"
-  method = "GET"
-  path   = "org/{org}/assessments/build-report"
-  options = [ "xcp_ci" ]
-  parameter "detail" {
-    literal_value = "true"
-  }
-  result {
-    path = [ "findings" ]
-    columns = [
-      "module", "pass", "severity", "sid", "description"
-    ]
+command "group" "iac-scan" {
+  command "print_client" "build-report" {
+    short   = "Display information about the assessments generated during the current CI build"
+    method  = "GET"
+    path    = "org/{org}/assessments/build-report"
+    options = ["xcp_ci"]
+    parameter "detail" {
+      literal_value = "true"
+    }
+    parameter "fail" {
+      usage = "Exit with failure if there are more than `level=count` failed findings"
+      disposition = "noop"
+      map = true
+    }
+    result {
+      local_action = "exit_on_failures"
+      path = ["findings"]
+      columns = [
+        "module", "pass", "severity", "sid", "description"
+      ]
+    }
   }
 }


### PR DESCRIPTION
* Move build-report to iac-scan, keep old location temporarily

* Add noop model parameter disposition

* Add support for map, string slice parameters (only noop supported for map for now)

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>