### PR TITLE
Add support for cfn_nag and more

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,13 +42,13 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Caching docker images
-      uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
     - name: Installing golangci-lint
       run: wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.31.0
     - name: Build and Unit Test
       run: ./hack/build.sh
+    - name: Caching docker images for test
+      uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
     - name: Test
       run: ./hack/test.sh
       env:

--- a/cmd/iacscan/iacscan.go
+++ b/cmd/iacscan/iacscan.go
@@ -1,10 +1,10 @@
 package iacscan
 
 import (
-	"github.com/soluble-ai/soluble-cli/cmd/buildreport"
 	"github.com/soluble-ai/soluble-cli/pkg/tools"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/all"
 	cfnpythonlint "github.com/soluble-ai/soluble-cli/pkg/tools/cfn-python-lint"
+	"github.com/soluble-ai/soluble-cli/pkg/tools/cfnnag"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/checkov"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/secrets"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/semgrep"
@@ -29,10 +29,7 @@ func Command() *cobra.Command {
 		tools.CreateCommand(&all.Tool{}),
 		tools.CreateCommand(&secrets.Tool{}),
 		tools.CreateCommand(&semgrep.Tool{}),
+		tools.CreateCommand(&cfnnag.Tool{}),
 	)
-	c.AddCommand(buildreport.Commands()...)
-
-	// Disabling the cloudformation guard for now as it doesn't fit our strategy
-	// c.AddCommand(createCommand(&cloudformationguard.Tool{}))
 	return c
 }

--- a/cmd/postcmd/postcmd.go
+++ b/cmd/postcmd/postcmd.go
@@ -1,7 +1,6 @@
 package postcmd
 
 import (
-	"github.com/soluble-ai/soluble-cli/pkg/api"
 	"github.com/soluble-ai/soluble-cli/pkg/options"
 	"github.com/soluble-ai/soluble-cli/pkg/xcp"
 	"github.com/spf13/cobra"
@@ -9,10 +8,9 @@ import (
 
 func Command() *cobra.Command {
 	var (
-		module  string
-		files   []string
-		values  map[string]string
-		withEnv bool
+		module string
+		files  []string
+		values map[string]string
 	)
 	opts := options.PrintClientOpts{
 		PrintOpts: options.PrintOpts{
@@ -24,11 +22,8 @@ func Command() *cobra.Command {
 		Short: "Send data to soluble",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var options []api.Option
-			if withEnv {
-				options = []api.Option{xcp.WithCIEnv}
-			}
-			result, err := opts.GetAPIClient().XCPPost(opts.GetOrganization(), module, files, values, options...)
+			result, err := opts.GetAPIClient().XCPPost(opts.GetOrganization(), module, files, values,
+				xcp.WithCIEnv)
 			if err != nil {
 				return err
 			}
@@ -38,7 +33,9 @@ func Command() *cobra.Command {
 	}
 	opts.Register(c)
 	flags := c.Flags()
-	flags.BoolVarP(&withEnv, "env", "e", false, "Include CI environment variables and git information.")
+	// on unconditionally -- hidden for backwards compatibility
+	flags.BoolP("env", "e", false, "Include CI environment variables and git information (always enabled).")
+	_ = flags.MarkHidden("env")
 	flags.StringVarP(&module, "module", "m", "", "The module to post under, required.")
 	flags.StringSliceVarP(&files, "file", "f", nil, "Send a file, can be repeated")
 	flags.StringToStringVarP(&values, "param", "p", nil, "Include a key value pair, can be repeated.  The argument should be in the form key=value.")

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/soluble-ai/soluble-cli/cmd/agent"
 	"github.com/soluble-ai/soluble-cli/cmd/auth"
 	"github.com/soluble-ai/soluble-cli/cmd/aws"
+	"github.com/soluble-ai/soluble-cli/cmd/build"
 	configcmd "github.com/soluble-ai/soluble-cli/cmd/config"
 	"github.com/soluble-ai/soluble-cli/cmd/downloadcmd"
 	"github.com/soluble-ai/soluble-cli/cmd/iacinventorycmd"
@@ -115,10 +116,10 @@ func Command() *cobra.Command {
 
 func setupCompat(rootCmd *cobra.Command) {
 	// temporary compatibility
-	buildReport := getCommandCopy(rootCmd, []string{"iac-scan", "build-report"})
+	buildReport := getCommandCopy(rootCmd, []string{"build", "report"})
 	buildReport.Hidden = true
 	options.AddPreRunE(buildReport, func(c *cobra.Command, s []string) error {
-		log.Warnf("This command has been moved to {warning:iac-scan build-report} and will be removed at some point")
+		log.Warnf("This command has been moved to {warning:build report} and will be removed at some point")
 		return nil
 	})
 	rootCmd.AddCommand(buildReport)
@@ -145,12 +146,16 @@ func addBuiltinCommands(rootCmd *cobra.Command) {
 		imagescan.Command(),
 		iacinventorycmd.Command(),
 		logincmd.Command(),
+		build.Command(),
 	)
 }
 
 func loadModels() {
 	if err := model.Load(getEmbeddedModelsSource()); err != nil {
 		panic(err)
+	}
+	if os.Getenv("SOLUBLE_DISABLE_CLI_MODELS") != "" {
+		return
 	}
 	sources := make(chan model.Source)
 	for _, loc := range config.GetModelLocations() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/avast/retry-go v2.7.0+incompatible
+	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/fatih/color v1.10.0
 	github.com/go-resty/resty/v2 v2.3.0
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,9 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar/v2 v2.0.4 h1:6I6oUiT/sU27eE2OFcWqBhL1SwjyvQuOssxT4a1yidI=
+github.com/bmatcuk/doublestar/v2 v2.0.4/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -126,8 +129,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jarcoal/httpmock v1.0.6 h1:e81vOSexXU3mJuJ4l//geOmKIt+Vkxerk1feQBC8D0g=
-github.com/jarcoal/httpmock v1.0.6/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
+github.com/jarcoal/httpmock v1.0.7 h1:d1a2VFpSdm5gtjhCPWsQHSnx8+5V3ms5431YwvmkuNk=
 github.com/jarcoal/httpmock v1.0.7/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -168,8 +170,6 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
-github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
-github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -11,10 +11,15 @@ run() {
     go run main.go ${@}
 }
 
+export SOLUBLE_OPTS=--force-color
+
 run version
 run auth profile --format none
 
 if [ -n "${SOLUBLE_API_TOKEN:-}" -a -n "${GITHUB_ACTIONS:-}" ]; then
-    run iac-scan all --upload --image nginx:1.19
-    run iac-scan update-ci
+    run iac-scan all --upload --image nginx:1.19 --skip secrets --exclude 'pkg/inventory/testdata/k/t/*.yaml'
+    # we don't have any secrets here, so the --error-not-empty will
+    # fail right away
+    run iac-scan secrets --exclude go.sum --error-not-empty --upload
+    run build update-pr
 fi

--- a/pkg/assessments/github/github.go
+++ b/pkg/assessments/github/github.go
@@ -20,7 +20,7 @@ type Integration struct {
 	gh     *github.Client
 }
 
-func NewIntegration(ctx context.Context, config *jnode.Node) assessments.CIIntegration {
+func NewIntegration(ctx context.Context, config *jnode.Node) assessments.PRIntegration {
 	gitRepo := config.Path("gitRepo").AsText()
 	if gitRepo == "" {
 		return nil
@@ -142,5 +142,5 @@ func truncate(s string, m int) string {
 }
 
 func init() {
-	assessments.RegisterCIIntegration(NewIntegration)
+	assessments.RegisterPRIntegration(NewIntegration)
 }

--- a/pkg/tools/cfn-python-lint/cfn-python-lint.go
+++ b/pkg/tools/cfn-python-lint/cfn-python-lint.go
@@ -1,13 +1,9 @@
 package cfnpythonlint
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/soluble-ai/go-jnode"
-	"github.com/soluble-ai/soluble-cli/pkg/inventory"
 	"github.com/soluble-ai/soluble-cli/pkg/tools"
 	"github.com/spf13/cobra"
 )
@@ -56,20 +52,8 @@ func (t *Tool) Run() (*tools.Result, error) {
 }
 
 func (t *Tool) findCloudformationFiles() ([]string, error) {
-	files := []string{}
 	if len(t.Templates) > 0 {
-		for _, f := range t.Templates {
-			rf := f
-			if filepath.IsAbs(f) {
-				if !strings.HasPrefix(f, t.GetDirectory()) {
-					return nil, fmt.Errorf("template file %s must be relative to --directory", f)
-				}
-			}
-			files = append(files, rf)
-		}
-	} else {
-		m := inventory.Do(t.GetDirectory())
-		files = m.CloudformationFiles.Values()
+		return t.GetFilesInDirectory(t.Templates)
 	}
-	return files, nil
+	return t.GetInventory().CloudformationFiles.Values(), nil
 }

--- a/pkg/tools/cfnnag/cfnnag.go
+++ b/pkg/tools/cfnnag/cfnnag.go
@@ -1,0 +1,83 @@
+package cfnnag
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/soluble-ai/go-jnode"
+	"github.com/soluble-ai/soluble-cli/pkg/tools"
+	"github.com/spf13/cobra"
+)
+
+type Tool struct {
+	tools.DirectoryBasedToolOpts
+	Templates []string
+}
+
+var _ tools.Interface = &Tool{}
+
+func (t *Tool) Name() string {
+	return "cfn_nag"
+}
+
+func (t *Tool) CommandTemplate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cfn-nag",
+		Short: "Scan cloudformation templates with cfn_nag",
+	}
+}
+
+func (t *Tool) Register(c *cobra.Command) {
+	t.DirectoryBasedToolOpts.Register(c)
+	c.Flags().StringSliceVar(&t.Templates, "template", nil,
+		"Run cfn_nag on these templates instead of automatically searching for them")
+}
+
+func (t *Tool) Run() (*tools.Result, error) {
+	files, err := t.findCloudformationFiles()
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no cloudformation templates found")
+	}
+	d, _ := t.RunDocker(&tools.DockerTool{
+		Name:      "cfn_nag",
+		Image:     "stelligent/cfn_nag:latest",
+		Directory: t.GetDirectory(),
+		Args:      append([]string{"--output-format=json"}, files...),
+	})
+	results, err := jnode.FromJSON(d)
+	if err != nil {
+		if d != nil {
+			os.Stderr.Write(d)
+		}
+		return nil, err
+	}
+	violations := jnode.NewArrayNode()
+	for _, f := range results.Elements() {
+		filename := f.Path("filename").AsText()
+		for _, v := range f.Path("file_results").Path("violations").Elements() {
+			violations.AppendObject().
+				Put("filename", filename).
+				Put("id", v.Path("id").AsText()).
+				Put("type", v.Path("type").AsText()).
+				Put("message", v.Path("message").AsText())
+		}
+	}
+	result := &tools.Result{
+		Directory:    t.Directory,
+		Data:         results,
+		PrintData:    jnode.NewObjectNode().Put("violations", violations),
+		PrintPath:    []string{"violations"},
+		PrintColumns: []string{"id", "type", "filename", "message"},
+	}
+	return result, nil
+}
+
+func (t *Tool) findCloudformationFiles() ([]string, error) {
+	if len(t.Templates) > 0 {
+		return t.GetFilesInDirectory(t.Templates)
+	}
+	return t.GetInventory().CloudformationFiles.Values(), nil
+}

--- a/pkg/tools/command.go
+++ b/pkg/tools/command.go
@@ -44,7 +44,7 @@ func runTool(tool Interface) error {
 	}
 	opts.Path = result.PrintPath
 	opts.Columns = result.PrintColumns
-	opts.PrintResult(result.Data)
+	opts.PrintResult(result.GetPrintData())
 	if !opts.UploadEnabled {
 		blurb.SignupBlurb(opts, "Want to manage findings with {primary:Soluble}?", "run this command again with the {info:--upload} flag")
 	}

--- a/pkg/tools/dir.go
+++ b/pkg/tools/dir.go
@@ -1,17 +1,27 @@
 package tools
 
 import (
+	"fmt"
 	"log"
 	"path/filepath"
+	"strings"
 
+	"github.com/bmatcuk/doublestar/v2"
+	"github.com/soluble-ai/soluble-cli/pkg/inventory"
+	"github.com/soluble-ai/soluble-cli/pkg/util"
 	"github.com/spf13/cobra"
 )
 
 type DirectoryBasedToolOpts struct {
 	ToolOpts
 	Directory string
+	Exclude   []string
 
 	absDirectory string
+}
+
+func (o *DirectoryBasedToolOpts) GetDirectoryBasedToolOptions() *DirectoryBasedToolOpts {
+	return o
 }
 
 func (o *DirectoryBasedToolOpts) GetDirectory() string {
@@ -29,7 +39,80 @@ func (o *DirectoryBasedToolOpts) GetDirectory() string {
 	return o.absDirectory
 }
 
+func (o *DirectoryBasedToolOpts) GetInventory() *inventory.Manifest {
+	m := inventory.Do(o.GetDirectory())
+	m.CloudformationFiles = o.removeExcludedStringSet(m.CloudformationFiles)
+	m.DockerDirectories = o.removeExcludedStringSet(m.DockerDirectories)
+	m.HelmCharts = o.removeExcludedStringSet(m.HelmCharts)
+	m.KubernetesManifestDirectories = o.removeExcludedStringSet(m.KubernetesManifestDirectories)
+	m.TerraformRootModuleDirectories = o.removeExcludedStringSet(m.TerraformRootModuleDirectories)
+	return m
+}
+
+func (o *DirectoryBasedToolOpts) GetFilesInDirectory(files []string) ([]string, error) {
+	var result []string
+	for _, f := range files {
+		if filepath.IsAbs(f) {
+			if !strings.HasPrefix(f, o.GetDirectory()) {
+				return nil, fmt.Errorf("file %s must be relative to --directory", f)
+			}
+		}
+		if !o.IsExcluded(f) {
+			result = append(result, f)
+		}
+	}
+	return result, nil
+}
+
+func (o *DirectoryBasedToolOpts) RemoveExcluded(files []string) []string {
+	var result []string
+	for _, f := range files {
+		if !o.IsExcluded(f) {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
+func (o *DirectoryBasedToolOpts) removeExcludedStringSet(ss util.StringSet) util.StringSet {
+	var r util.StringSet
+	for _, v := range ss.Values() {
+		if !o.IsExcluded(v) {
+			r.Add(v)
+		}
+	}
+	return r
+}
+
+func (o *DirectoryBasedToolOpts) IsExcluded(file string) bool {
+	if filepath.IsAbs(file) {
+		file, _ = filepath.Abs(file)
+	}
+	for _, pat := range o.Exclude {
+		m, _ := doublestar.PathMatch(pat, file)
+		if m {
+			return true
+		}
+	}
+	return false
+}
+
 func (o *DirectoryBasedToolOpts) Register(cmd *cobra.Command) {
 	o.ToolOpts.Register(cmd)
-	cmd.Flags().StringVarP(&o.Directory, "directory", "d", "", "The directory to run in.")
+	flags := cmd.Flags()
+	flags.StringVarP(&o.Directory, "directory", "d", "", "The directory to run in.")
+	flags.StringSliceVar(&o.Exclude, "exclude", nil, "Exclude results from file that match this glob pattern (path/**/foo.txt syntax supported.)  May be repeated.")
+}
+
+func (o *DirectoryBasedToolOpts) Validate() error {
+	if err := o.ToolOpts.Validate(); err != nil {
+		return err
+	}
+	for _, pat := range o.Exclude {
+		_, err := doublestar.PathMatch(pat, "test")
+		if err != nil {
+			return fmt.Errorf("invalid --exclude pattern '%s': %w", pat, err)
+		}
+	}
+	return nil
 }

--- a/pkg/tools/iacinventory/local.go
+++ b/pkg/tools/iacinventory/local.go
@@ -1,7 +1,6 @@
 package iacinventory
 
 import (
-	"github.com/soluble-ai/soluble-cli/pkg/inventory"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/print"
 	"github.com/soluble-ai/soluble-cli/pkg/tools"
@@ -32,7 +31,7 @@ func (t *Local) CommandTemplate() *cobra.Command {
 
 func (t *Local) Run() (*tools.Result, error) {
 	log.Infof("Finding local infrastructure-as-code inventory under {primary:%s}", t.GetDirectory())
-	m := inventory.Do(t.GetDirectory())
+	m := t.GetInventory()
 	n, _ := print.ToResult(m)
 	r := &tools.Result{
 		Data: n,

--- a/pkg/tools/result.go
+++ b/pkg/tools/result.go
@@ -22,6 +22,7 @@ import (
 
 type Result struct {
 	Data         *jnode.Node
+	PrintData    *jnode.Node
 	Values       map[string]string
 	Directory    string
 	Files        *util.StringSet
@@ -36,6 +37,13 @@ var repoFiles = []string{
 	"CODEOWNERS",
 	"docs/CODEOWNERS",
 	".github/CODEOWNERS",
+}
+
+func (r *Result) GetPrintData() *jnode.Node {
+	if r.PrintData != nil {
+		return r.PrintData
+	}
+	return r.Data
 }
 
 func (r *Result) AddFile(path string) *Result {

--- a/pkg/tools/secrets/secrets.go
+++ b/pkg/tools/secrets/secrets.go
@@ -33,6 +33,9 @@ func (t *Tool) Run() (*tools.Result, error) {
 
 	output := jnode.NewArrayNode()
 	for k, v := range results.Path("results").Entries() {
+		if t.IsExcluded(k) {
+			continue
+		}
 		if v.IsArray() {
 			for _, p := range v.Elements() {
 				p.Put("file_name", k)

--- a/pkg/tools/semgrep/semgrep.go
+++ b/pkg/tools/semgrep/semgrep.go
@@ -79,6 +79,12 @@ func (t *Tool) Run() (*tools.Result, error) {
 		}
 		return nil, fmt.Errorf("could not parse JSON: %w", err)
 	}
+	results := n.Path("results")
+	if results.Size() > 0 {
+		n.Put("results", util.RemoveJNodeElementsIf(results, func(e *jnode.Node) bool {
+			return t.IsExcluded(e.Path("path").AsText())
+		}))
+	}
 	result := &tools.Result{
 		Data:      n,
 		PrintPath: []string{"results"},

--- a/pkg/tools/terrascan/terrascan.go
+++ b/pkg/tools/terrascan/terrascan.go
@@ -58,6 +58,14 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	for _, result := range n.Path("results").Elements() {
+		violations := result.Path("violations")
+		if violations.Size() > 0 {
+			result.Put("violations", util.RemoveJNodeElementsIf(violations, func(e *jnode.Node) bool {
+				return t.IsExcluded(e.Path("file").AsText())
+			}))
+		}
+	}
 	result := &tools.Result{
 		Data:         n,
 		Directory:    t.GetDirectory(),

--- a/pkg/tools/tool.go
+++ b/pkg/tools/tool.go
@@ -5,6 +5,7 @@ import "github.com/soluble-ai/soluble-cli/pkg/options"
 type Interface interface {
 	options.Interface
 	GetToolOptions() *ToolOpts
+	GetDirectoryBasedToolOptions() *DirectoryBasedToolOpts
 	Validate() error
 	Run() (*Result, error)
 	Name() string

--- a/pkg/util/remove.go
+++ b/pkg/util/remove.go
@@ -1,0 +1,24 @@
+package util
+
+import "github.com/soluble-ai/go-jnode"
+
+func RemoveJNodeElementsIf(n *jnode.Node, f func(*jnode.Node) bool) *jnode.Node {
+	// don't allocate a new array if the filter doesn't exclude anything
+	var result *jnode.Node
+	for i, e := range n.Elements() {
+		if f(e) {
+			if result == nil {
+				result = jnode.NewArrayNode()
+				for j := 0; j < i; j++ {
+					result.Append(n.Get(j))
+				}
+			}
+		} else if result != nil {
+			result.Append(e)
+		}
+	}
+	if result != nil {
+		return result
+	}
+	return n
+}

--- a/pkg/util/remove_test.go
+++ b/pkg/util/remove_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/soluble-ai/go-jnode"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveJNodeElementsIf(t *testing.T) {
+	assert := assert.New(t)
+	n := jnode.NewArrayNode().Append("hello").
+		Append("world").
+		Append("one").
+		Append("two").
+		Append("three")
+	m := RemoveJNodeElementsIf(n, func(*jnode.Node) bool { return false })
+	assert.Same(n, m)
+	l := RemoveJNodeElementsIf(n, func(e *jnode.Node) bool { return e.AsText() == "two" })
+	assert.Equal(4, l.Size())
+	assert.Equal("hello", l.Get(0).AsText())
+	assert.Equal("three", l.Get(3).AsText())
+}


### PR DESCRIPTION
* Add iac-scan cfn-nag to scan with cfn_nag

* Add --exclude option to directory based tools to exclude that match patterns

* build-report is now "build report"

* update-ci is now "build update-pr"

* tool.PrintData allows for different print data than tool.Data

* Don't send "soluble_print_config" with results any more

* "post -e" is now always enabled

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>