### PR TITLE
githooks

### DIFF
--- a/cmd/githooks/githooks.go
+++ b/cmd/githooks/githooks.go
@@ -1,0 +1,111 @@
+package githook
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/soluble-ai/soluble-cli/pkg/download"
+	"github.com/soluble-ai/soluble-cli/pkg/log"
+	"github.com/soluble-ai/soluble-cli/pkg/options"
+	"github.com/spf13/cobra"
+)
+
+func installCommand() *cobra.Command {
+	var (
+		force    bool
+		noEditor bool
+	)
+	opts := options.PrintOpts{}
+	c := &cobra.Command{
+		Use:   "install",
+		Short: "Install git hooks in the current repository's .git/hooks/ directory",
+		Long: `Install githook templates from github.com/soluble-ai/githooks
+
+For repos with application source code:
+  $ soluble githook install app    # github.com/soluble-ai/githooks/tree/master/app
+
+For repos with IaC files:
+  $ soluble githook install iac    # github.com/soluble-ai/githooks/tree/master/iac`,
+		Args:      cobra.ExactValidArgs(1),
+		ValidArgs: []string{"app", "iac"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isGitRepository() {
+				return fmt.Errorf("current directory is not the root of a git repository")
+			}
+			mgr := download.NewManager()
+			dl, err := mgr.Install(&download.Spec{
+				Name: "githooks",
+				URL:  "https://github.com/soluble-ai/githooks/archive/master.zip",
+			})
+			if err != nil {
+				return fmt.Errorf("error downloading githooks: %w", err)
+			}
+			hookDir := filepath.Join(dl.Dir, "githooks-master", strings.Join(args, ""))
+			hookDirInfo, err := os.Stat(hookDir)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("githook directory does not exist: %q", hookDir)
+				}
+				return fmt.Errorf("error checking githook directory: %w", err)
+			}
+			if !hookDirInfo.IsDir() {
+				return fmt.Errorf("githook directory was file, not directory: %q", hookDir)
+			}
+			err = filepath.Walk(hookDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				hookDat, err := ioutil.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("error reading hook file %q: %w", path, err)
+				}
+				hookFile := filepath.Join(".git/hooks", info.Name())
+				_, err = os.Stat(hookFile)
+				if os.IsNotExist(err) || force {
+					if err := ioutil.WriteFile(hookFile, hookDat, 0o755); err != nil { //nolint: gosec // executable permissions are expected here
+						return fmt.Errorf("error writing hook file: %q: %w", hookFile, err)
+					}
+					log.Infof("wrote hook file: %q", hookFile)
+				} else {
+					if err != nil {
+						return fmt.Errorf("error stating hook file: %q: %w", path, err)
+					}
+					return fmt.Errorf("hook files already exist. To force update, re-run with --force")
+				}
+				return nil
+			})
+			return err
+		},
+	}
+	opts.Register(c)
+	c.Flags().BoolVar(&force, "force", false, "Force installation of hooks, overwriting existing hooks")
+	c.Flags().BoolVar(&noEditor, "no-editor", false, "Do not automatically open $EDITOR for installed hooks")
+	return c
+}
+
+func Command() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "githook",
+		Aliases: []string{"githooks", "hooks"},
+		Short:   "Manage git hooks",
+	}
+	c.AddCommand(installCommand())
+	return c
+}
+
+func isGitRepository() bool {
+	f, err := os.Stat(".git")
+	if os.IsNotExist(err) {
+		return false
+	}
+	if f.IsDir() {
+		return true
+	}
+	return false
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -27,6 +27,7 @@ import (
 	configcmd "github.com/soluble-ai/soluble-cli/cmd/config"
 	"github.com/soluble-ai/soluble-cli/cmd/depscan"
 	"github.com/soluble-ai/soluble-cli/cmd/downloadcmd"
+	githook "github.com/soluble-ai/soluble-cli/cmd/githooks"
 	"github.com/soluble-ai/soluble-cli/cmd/imagescan"
 	"github.com/soluble-ai/soluble-cli/cmd/inventorycmd"
 	"github.com/soluble-ai/soluble-cli/cmd/k8sscan"
@@ -160,6 +161,7 @@ func addBuiltinCommands(rootCmd *cobra.Command) {
 		cfnscan.Command(),
 		tools.CreateCommand(&autoscan.Tool{}),
 		tools.CreateCommand(&checkov.Tool{}),
+		githook.Command(),
 	)
 }
 

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/gjson v1.6.7 h1:Mb1M9HZCRWEcXQ8ieJo7auYyyiSux6w9XN3AdTpxJrE=


### PR DESCRIPTION
Add command to install git hooks in the current repository (from github.com/soluble-ai/githooks).

```
$ ./soluble-cli githook install -h
Install githook templates from github.com/soluble-ai/githooks

For repos with application source code:
  $ soluble githook install app    # github.com/soluble-ai/githooks/tree/master/app

For repos with IaC files:
  $ soluble githook install iac    # github.com/soluble-ai/githooks/tree/master/iac
```

Example usage:
```
matt at MacBookAir in ~/go/src/github.com/soluble-ai/soluble-cli (githooks)
$ l .git/hooks                

matt at MacBookAir in ~/go/src/github.com/soluble-ai/soluble-cli (githooks)
$ ./soluble-cli githook install app
[ Info] Getting https://github.com/soluble-ai/githooks/archive/master.zip
[ Info] Installing master.zip
[ Info] Latest release of githooks is 
[ Info] wrote hook file: ".git/hooks/pre-push"

matt at MacBookAir in ~/go/src/github.com/soluble-ai/soluble-cli (githooks)
$ l .git/hooks                     
total 8
-rwxr-xr-x  1 matt  staff   466B Jan 15 16:21 pre-push
```