### PR TITLE
Don't include repoPath in findings for terraform module files not in …

### DIFF
--- a/pkg/assessments/assessments.go
+++ b/pkg/assessments/assessments.go
@@ -47,14 +47,15 @@ type Assessment struct {
 type Assessments []*Assessment
 
 type Finding struct {
-	SID         string `json:"sid,omitempty"`
-	Severity    string `json:"severity,omitempty"`
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
-	Markdown    string `json:"markdown,omitempty"`
-	FilePath    string `json:"filePath,omitempty"`
-	Line        int    `json:"line,omitempty"`
-	Pass        bool   `json:"pass,omitempty"`
+	SID           string `json:"sid,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Title         string `json:"title,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Markdown      string `json:"markdown,omitempty"`
+	FilePath      string `json:"filePath,omitempty"`
+	Line          int    `json:"line,omitempty"`
+	Pass          bool   `json:"pass,omitempty"`
+	GeneratedFile bool   `json:"generated_filed,omitempty"`
 
 	// These fields are filled in by the CLI and sent to
 	RepoPath           string            `json:"repoPath,omitempty"`
@@ -98,7 +99,7 @@ func (findings Findings) ComputePartialFingerprints(dir string) {
 		if f.FilePath != "" && f.Line > 0 {
 			findingsForFiles[f.FilePath] = append(findingsForFiles[f.FilePath], f)
 		}
-		if f.FilePath != "" && relDir != "" {
+		if f.FilePath != "" && relDir != "" && !f.GeneratedFile {
 			f.RepoPath = filepath.Join(relDir, f.FilePath)
 		}
 	}

--- a/pkg/tools/result_test.go
+++ b/pkg/tools/result_test.go
@@ -73,7 +73,7 @@ func TestUpload(t *testing.T) {
 			assert.Equal(h.FormValue("FOO"), "hello")
 			return resp, err
 		})
-	assert.Nil(result.report(opts, nil, "test"))
+	assert.Nil(result.report(opts, nil, "test", true))
 	assert.Equal("http://app.example.com/A1", result.Assessment.URL)
 }
 

--- a/pkg/tools/tfsec/tfsec.go
+++ b/pkg/tools/tfsec/tfsec.go
@@ -160,9 +160,10 @@ func (t *Tool) parseResults(n *jnode.Node) *tools.Result {
 				continue
 			}
 			findings = append(findings, &assessments.Finding{
-				FilePath:    filename,
-				Line:        r.Path("location").Path("start_line").AsInt(),
-				Description: r.Path("description").AsText(),
+				FilePath:      filename,
+				Line:          r.Path("location").Path("start_line").AsInt(),
+				Description:   r.Path("description").AsText(),
+				GeneratedFile: strings.HasPrefix(filepath.ToSlash(filename), ".terraform/modules/"),
 				Tool: map[string]string{
 					"severity": r.Path("severity").AsText(),
 					"rule_id":  r.Path("rule_id").AsText(),

--- a/pkg/tools/toolopts.go
+++ b/pkg/tools/toolopts.go
@@ -203,12 +203,10 @@ func (o *ToolOpts) RunTool(printResult bool) (*Result, error) {
 		writeResultValues(f, result)
 		_ = f.Close()
 	}
-	if o.UploadEnabled {
-		err = result.Report(o.Tool)
-		if err == nil && o.UpdatePR {
-			if result.Assessment != nil {
-				err = result.Assessment.UpdatePR(o.GetAPIClient())
-			}
+	err = result.Report(o.Tool, o.UploadEnabled)
+	if err == nil && o.UpdatePR {
+		if result.Assessment != nil {
+			err = result.Assessment.UpdatePR(o.GetAPIClient())
 		}
 	}
 	return result, err

--- a/pkg/xcp/xcp.go
+++ b/pkg/xcp/xcp.go
@@ -132,7 +132,9 @@ envLoop:
 			// and if we haven't set a CI system yet, set it
 			if ciSystem == "" {
 				idx := strings.Index(k, "_")
-				ciSystem = k[:idx]
+				if idx > 0 {
+					ciSystem = k[:idx]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
…repo

* For tfsec and checkov, don't set repoPath if the file is in .modules
or .external_modules respectively

* Make --print-fingerprints, --print-result-values work even if --upload
is not given

* Note how to turn on external module download in checkov help text.

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>