### PR TITLE
Change .soluble directory to .lacework

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -49,7 +49,9 @@ func profileCmd() *cobra.Command {
 				return err
 			}
 			if config.UpdateFromServerProfile(result) {
-				config.Save()
+				if err := config.Save(); err != nil {
+					return err
+				}
 			}
 			opts.PrintResult(result)
 			return nil
@@ -100,7 +102,9 @@ func setAccessTokenCmd() *cobra.Command {
 			config.Config.APIServer = cfg.APIServer
 			config.Config.TLSNoVerify = cfg.TLSNoVerify
 			config.UpdateFromServerProfile(result)
-			config.Save()
+			if err := config.Save(); err != nil {
+				return err
+			}
 			log.Infof("Current org is {info:%s}", config.Config.Organization)
 			return nil
 		},
@@ -125,7 +129,9 @@ func setOrgCommand() *cobra.Command {
 				return err
 			}
 			if config.UpdateFromServerProfile(result) {
-				config.Save()
+				if err := config.Save(); err != nil {
+					return err
+				}
 			}
 			log.Infof("Current org set to {info:%s}", config.Config.Organization)
 			return nil

--- a/cmd/logincmd/logincmd.go
+++ b/cmd/logincmd/logincmd.go
@@ -58,9 +58,8 @@ func Command() *cobra.Command {
 			config.Config.APIServer = resp.APIServer
 			config.Config.APIToken = resp.Token
 			config.Config.Organization = resp.OrgID
-			config.Save()
-			log.Infof("Authentication successful")
-			return nil
+			defer log.Infof("Authentication successful")
+			return config.Save()
 		},
 	}
 	opts.Register(c)

--- a/cmd/model/model.go
+++ b/cmd/model/model.go
@@ -81,8 +81,7 @@ func addModel() *cobra.Command {
 			}
 			log.Infof("Added model source {info:%s}", source)
 			config.GlobalConfig.ModelLocations = append(config.GlobalConfig.ModelLocations, url)
-			config.Save()
-			return nil
+			return config.Save()
 		},
 	}
 	opts.Register(c)

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -69,7 +69,9 @@ func Command() *cobra.Command {
 			log.Debugf("Loaded configuration from {primary:%s}", config.ConfigFile)
 			if setProfile != "" {
 				config.SelectProfile(setProfile)
-				config.Save()
+				if err := config.Save(); err != nil {
+					return err
+				}
 			}
 			if profile != "" {
 				config.SelectProfile(profile)

--- a/cmd/root/update_auth.go
+++ b/cmd/root/update_auth.go
@@ -31,7 +31,9 @@ func updateAuthAction(command model.Command, result *jnode.Node) (*jnode.Node, e
 	config.Config.APIToken = result.Path("token").AsText()
 	config.Config.Email = result.Path("user").Path("email").AsText()
 	config.Config.Organization = result.Path("user").Path("currentOrgId").AsText()
-	config.Save()
+	if err := config.Save(); err != nil {
+		return nil, err
+	}
 	result.Put("token", config.Redacted)
 	return result, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,9 +19,12 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig(t *testing.T) {
+	assert := assert.New(t)
 	f, err := ioutil.TempFile("", "config")
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +34,7 @@ func TestConfig(t *testing.T) {
 	os.Remove(ConfigFile)
 	Load()
 	Config.APIToken = "xxx"
-	Save()
+	assert.NoError(Save())
 	defer os.Remove(ConfigFile)
 	Load()
 	if Config.APIToken != "xxx" {
@@ -42,7 +45,7 @@ func TestConfig(t *testing.T) {
 		t.Error(GlobalConfig)
 	}
 	Config.APIToken = "yyy"
-	Save()
+	assert.NoError(Save())
 	Load()
 	if GlobalConfig.CurrentProfile != "test" || Config.APIToken != "yyy" {
 		t.Error(GlobalConfig)

--- a/pkg/tools/result.go
+++ b/pkg/tools/result.go
@@ -45,6 +45,7 @@ type Result struct {
 }
 
 var repoFiles = []string{
+	".lacework/config.yml",
 	".soluble/config.yml",
 	"CODEOWNERS",
 	"docs/CODEOWNERS",

--- a/pkg/tools/toolopts.go
+++ b/pkg/tools/toolopts.go
@@ -31,6 +31,7 @@ import (
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/options"
 	"github.com/soluble-ai/soluble-cli/pkg/print"
+	"github.com/soluble-ai/soluble-cli/pkg/util"
 	"github.com/soluble-ai/soluble-cli/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -69,7 +70,13 @@ func (o *ToolOpts) GetConfig() *Config {
 
 func (o *ToolOpts) getConfig(repoRoot string) *Config {
 	if o.config == nil {
-		o.config = ReadConfig(filepath.Join(repoRoot, ".soluble"))
+		if util.FileExists(filepath.Join(repoRoot, ".soluble", "config.yml")) &&
+			!util.FileExists(filepath.Join(repoRoot, ".lacework", "config.yml")) {
+			log.Warnf("{info:.soluble/config.yml} is {warning:deprecated}.  Use {info:.lacework/config.yml} instead.")
+			o.config = ReadConfig(filepath.Join(repoRoot, ".soluble"))
+		} else {
+			o.config = ReadConfig(filepath.Join(repoRoot, ".lacework"))
+		}
 	}
 	return o.config
 }

--- a/pkg/util/exists.go
+++ b/pkg/util/exists.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func FileExists(path string) bool {
+	_, err := os.Stat(filepath.FromSlash(path))
+	return err == nil
+}

--- a/pkg/util/exists_test.go
+++ b/pkg/util/exists_test.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExists(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(FileExists("exists.go"))
+	assert.False(FileExists("foo/nope.go"))
+}


### PR DESCRIPTION
* Use (and log) .soluble/cli-config.json if it exists and .lacework/cli-config.json doesn't

* Add "soluble config migrate" command to put config file in the right location

* Send and read .lacework/config.yml in preference to .soluble/config.yml during build

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>