### PR TITLE
For cdk-scan, default --cdk-synth=true

### DIFF
--- a/cmd/root/help.go
+++ b/cmd/root/help.go
@@ -76,7 +76,6 @@ Some options have been hidden, use "{{ helpPath $ }} -a" to display all options{
 		globalOptionsHelp,
 		(&tools.ToolOpts{}).GetToolHiddenOptions().GetHelpCommand(),
 		(&tools.RunOpts{}).GetRunHiddenOptions().GetHelpCommand(),
-		(&tools.DirectoryBasedToolOpts{}).GetDirectoryBasedHiddenOptions().GetHelpCommand(),
 	)
 }
 

--- a/pkg/tools/checkov/cdk.go
+++ b/pkg/tools/checkov/cdk.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/tools"
 	"github.com/soluble-ai/soluble-cli/pkg/util"
 	"github.com/spf13/cobra"
@@ -28,8 +30,8 @@ func (cdk *CDK) Register(cmd *cobra.Command) {
 	cdk.DirectoryBasedToolOpts.Register(cmd)
 	flags := cmd.Flags()
 	flags.StringVar(&cdk.OutDirectory, "cdk-out", "cdk.out", "The CDK output directory.")
-	flags.BoolVar(&cdk.Synth, "cdk-synth", false, "Run \"cdk synth\" before scanning. ")
-	flags.StringSliceVar(&cdk.SynthArgs, "cdk-synth-args", nil, "Pass these arguments to \"cdk synth\".  Command separated, may be repeated.")
+	flags.BoolVar(&cdk.Synth, "cdk-synth", true, "Run \"cdk synth\" before scanning. Use --cdk-synth=false to disable.")
+	flags.StringSliceVar(&cdk.SynthArgs, "cdk-synth-args", nil, "Pass these arguments to \"cdk synth\".  Comma separated, may be repeated.")
 }
 
 func (cdk *CDK) Validate() error {
@@ -39,18 +41,41 @@ func (cdk *CDK) Validate() error {
 	if !util.FileExists(filepath.Join(cdk.GetDirectory(), "cdk.json")) {
 		return fmt.Errorf("cannot run cdk-scan in %s because it's not a CDK directory", cdk.GetDirectory())
 	}
+	cdkOut := cdk.getOutDirectory()
+	if !cdk.Synth {
+		if !util.DirExists(cdkOut) || util.DirEmpty(cdkOut) {
+			return fmt.Errorf("cdk output directory %s does not exist or is empty", cdkOut)
+		}
+	}
+	rel, err := filepath.Rel(cdk.GetDirectory(), cdkOut)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		// The cdk.out directory must be a sub-directory of the directory we're running
+		// in because we're using docker.
+		return fmt.Errorf("cdk output directory %s must be relative to %s", cdk.OutDirectory, cdk.GetDirectory())
+	}
 	return nil
+}
+
+func (cdk *CDK) getOutDirectory() string {
+	if filepath.IsAbs(cdk.OutDirectory) {
+		return cdk.OutDirectory
+	}
+	return filepath.Join(cdk.GetDirectory(), cdk.OutDirectory)
 }
 
 func (cdk *CDK) Run() (*tools.Result, error) {
 	if cdk.Synth {
 		args := append([]string{"synth"}, cdk.SynthArgs...)
+		if len(cdk.SynthArgs) == 0 {
+			args = append(args, "--quiet")
+		}
 		synth := exec.Command("cdk", args...)
 		synth.Dir = cdk.GetDirectory()
 		synth.Stderr = os.Stderr
 		synth.Stdout = os.Stderr
 		cdk.LogCommand(synth)
 		if err := synth.Run(); err != nil {
+			log.Errorf("{primary:cdk synth} failed.  Run cdk synth manually and use {primary:--cdk-synth=false}.")
 			return nil, err
 		}
 	}
@@ -58,7 +83,7 @@ func (cdk *CDK) Run() (*tools.Result, error) {
 		DirectoryBasedToolOpts: cdk.DirectoryBasedToolOpts,
 		Framework:              "cloudformation",
 	}
-	checkov.Directory = filepath.Join(cdk.GetDirectory(), cdk.OutDirectory)
+	checkov.Directory = cdk.getOutDirectory()
 	if err := checkov.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/tools/diropts.go
+++ b/pkg/tools/diropts.go
@@ -22,18 +22,14 @@ import (
 	ignore "github.com/sabhiram/go-gitignore"
 	"github.com/soluble-ai/soluble-cli/pkg/inventory"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
-	"github.com/soluble-ai/soluble-cli/pkg/options"
 	"github.com/soluble-ai/soluble-cli/pkg/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type DirectoryBasedToolOpts struct {
 	ToolOpts
-	Directory         string
-	Exclude           []string
-	PrintFingerprints bool
-	SaveFingerprints  string
+	Directory string
+	Exclude   []string
 
 	absDirectory string
 	ignore       *ignore.GitIgnore
@@ -128,23 +124,11 @@ func (o *DirectoryBasedToolOpts) GetDockerRunDirectory() string {
 	return "/src"
 }
 
-func (o *DirectoryBasedToolOpts) GetDirectoryBasedHiddenOptions() *options.HiddenOptionsGroup {
-	return &options.HiddenOptionsGroup{
-		Name: "directory-based-options",
-		Long: "Options for running tools in a directory",
-		CreateFlagsFunc: func(flags *pflag.FlagSet) {
-			flags.BoolVar(&o.PrintFingerprints, "print-fingerprints", false, "Print fingerprints on stderr before uploading results")
-			flags.StringVar(&o.SaveFingerprints, "save-fingerprints", "", "Save finding fingerprints to `file`")
-		},
-	}
-}
-
 func (o *DirectoryBasedToolOpts) Register(cmd *cobra.Command) {
 	o.ToolOpts.Register(cmd)
 	flags := cmd.Flags()
 	flags.StringVarP(&o.Directory, "directory", "d", "", "The directory to run in.")
 	flags.StringSliceVar(&o.Exclude, "exclude", nil, "Exclude results from file that match this glob pattern (path/**/foo.txt syntax supported.)  May be repeated.")
-	o.GetDirectoryBasedHiddenOptions().Register(cmd)
 }
 
 func (o *DirectoryBasedToolOpts) Validate() error {

--- a/pkg/tools/docker.go
+++ b/pkg/tools/docker.go
@@ -59,12 +59,11 @@ func (t *DockerTool) run(skipPull bool) ([]byte, error) {
 		return nil, err
 	}
 	if !skipPull {
-		log.Infof("Pulling {primary:%s}", t.Image)
 		// #nosec G204
 		pull := exec.Command("docker", "pull", t.Image)
-		pull.Stderr = os.Stderr
-		pull.Stdout = os.Stdout
-		if err := pull.Run(); err != nil {
+		out, err := pull.Output()
+		if err != nil {
+			os.Stderr.Write(out)
 			log.Warnf("docker pull {primary:%s} failed: {warning:%s}", t.Image, err)
 		}
 	}

--- a/pkg/tools/formatters.go
+++ b/pkg/tools/formatters.go
@@ -22,3 +22,11 @@ func PassFormatter(n *jnode.Node) string {
 	}
 	return "FAIL"
 }
+
+func MissingFormatter(n *jnode.Node) string {
+	t := n.AsText()
+	if t == "" {
+		return "?"
+	}
+	return t
+}

--- a/pkg/tools/formatters_test.go
+++ b/pkg/tools/formatters_test.go
@@ -25,3 +25,8 @@ func TestPassFormatter(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal("PASS", PassFormatter(jnode.NewObjectNode().Put("pass", true).Path("pass")))
 }
+
+func TestMissingFormatter(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("?", MissingFormatter(jnode.NewObjectNode().Path("missing")))
+}

--- a/pkg/tools/result.go
+++ b/pkg/tools/result.go
@@ -129,8 +129,11 @@ func (r *Result) Upload(client *api.Client, org, name string) error {
 	return nil
 }
 
-func (r *Result) UpdateFileFingerprints(dir string) {
-	r.Findings.ComputePartialFingerprints(dir)
+func (r *Result) UpdateFileFingerprints() {
+	if r.Directory == "" {
+		return
+	}
+	r.Findings.ComputePartialFingerprints(r.Directory)
 	m := map[string]*assessments.Finding{}
 	for _, f := range r.Findings {
 		if f.PartialFingerprint == "" {

--- a/pkg/tools/tfscore/tfscore.go
+++ b/pkg/tools/tfscore/tfscore.go
@@ -50,7 +50,7 @@ func (t *Tool) Validate() error {
 	if t.Directory == "" {
 		t.Directory = filepath.Dir(t.PlanFile)
 	}
-	return t.GetDirectoryBasedToolOptions().Validate()
+	return t.DirectoryBasedToolOpts.Validate()
 }
 
 func (t *Tool) Run() (*tools.Result, error) {

--- a/pkg/util/exists.go
+++ b/pkg/util/exists.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 )
@@ -8,4 +9,23 @@ import (
 func FileExists(path string) bool {
 	_, err := os.Stat(filepath.FromSlash(path))
 	return err == nil
+}
+
+func DirExists(path string) bool {
+	di, err := os.Stat(filepath.FromSlash(path))
+	if err == nil && di.IsDir() {
+		return true
+	}
+	return false
+}
+
+func DirEmpty(path string) bool {
+	es, err := os.ReadDir(path)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	if err == nil && len(es) == 0 {
+		return true
+	}
+	return false
 }

--- a/pkg/util/exists_test.go
+++ b/pkg/util/exists_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,4 +11,13 @@ func TestExists(t *testing.T) {
 	assert := assert.New(t)
 	assert.True(FileExists("exists.go"))
 	assert.False(FileExists("foo/nope.go"))
+	assert.True(DirExists("../util"))
+	assert.False(DirExists("foo"))
+	assert.False(DirEmpty("."))
+	d, err := os.MkdirTemp("", "test*")
+	if assert.NoError(err) {
+		defer os.RemoveAll(d)
+		assert.True(DirExists(d))
+		assert.True(DirEmpty(d))
+	}
 }


### PR DESCRIPTION
* For tools.Result processing, use directory from result instead of from tool

* Remove unecessary directory-based-options group

* Don't log the docker pull command unless it fails

* For cdk-scan, require cdk.out directory be a sub-directory of the tool
directory, verify that the cdk.out directory exists and is non-empty,
use "cdk synth --quiet" by default, and suggest "--cdk-synth=false"
if cdk synth fails.

* Put ? in sid, severity when --upload=false

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>