### PR TITLE
Add multiDocumentFile indicator to file fingerprints

### DIFF
--- a/pkg/tools/checkov/cdk.go
+++ b/pkg/tools/checkov/cdk.go
@@ -87,5 +87,12 @@ func (cdk *CDK) Run() (*tools.Result, error) {
 	if err := checkov.Validate(); err != nil {
 		return nil, err
 	}
-	return checkov.Run()
+	result, err := checkov.Run()
+	if result != nil {
+		// all cdk findings are in generated files
+		for _, f := range result.Findings {
+			f.GeneratedFile = true
+		}
+	}
+	return result, err
 }

--- a/pkg/tools/checkov/checkov.go
+++ b/pkg/tools/checkov/checkov.go
@@ -203,7 +203,7 @@ func (t *Tool) processChecks(result *tools.Result, checks *jnode.Node, checkType
 	})
 	for _, n := range checks.Elements() {
 		path := n.Path("file_path").AsText()
-		result.Findings = append(result.Findings, &assessments.Finding{
+		finding := &assessments.Finding{
 			Tool: map[string]string{
 				"check_id":   n.Path("check_id").AsText(),
 				"check_type": checkType,
@@ -212,8 +212,16 @@ func (t *Tool) processChecks(result *tools.Result, checks *jnode.Node, checkType
 			Line:          n.Path("file_line_range").Get(0).AsInt(),
 			Pass:          pass,
 			Title:         n.Path("check_name").AsText(),
-			GeneratedFile: strings.HasPrefix(filepath.ToSlash(path), ".external_modules/"),
-		})
+			GeneratedFile: t.isGeneratedFile(path),
+		}
+		result.Findings = append(result.Findings, finding)
 	}
 	return checks
+}
+
+func (t *Tool) isGeneratedFile(path string) bool {
+	if t.Framework == "" || t.Framework == "terraform" {
+		return strings.HasPrefix(filepath.ToSlash(path), ".external_modules/")
+	}
+	return false
 }

--- a/pkg/tools/checkov/helm.go
+++ b/pkg/tools/checkov/helm.go
@@ -24,6 +24,9 @@ func (h *Helm) RunAll() (tools.Results, error) {
 		errs    error
 	)
 	inventory := h.GetInventory()
+	if len(inventory.HelmCharts.Values()) == 0 {
+		return nil, fmt.Errorf("no helm charts found under %s", h.GetDirectory())
+	}
 	for _, chart := range inventory.HelmCharts.Values() {
 		checkov := &Tool{
 			DirectoryBasedToolOpts: h.DirectoryBasedToolOpts,

--- a/pkg/tools/checkov/testdata/k/k8s.yaml
+++ b/pkg/tools/checkov/testdata/k/k8s.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: default
+spec:
+  externalName: api.example.com

--- a/pkg/tools/config.go
+++ b/pkg/tools/config.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	ignore "github.com/sabhiram/go-gitignore"
 	"github.com/soluble-ai/go-jnode"
@@ -51,9 +50,8 @@ func (c *Config) IsIgnored(path string) bool {
 	return c.ignore.MatchesPath(path)
 }
 
-func ReadConfig(dir string) *Config {
+func ReadConfigFile(path string) *Config {
 	c := &Config{}
-	path := filepath.Join(dir, "config.yml")
 	d, err := ioutil.ReadFile(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {

--- a/pkg/tools/result_test.go
+++ b/pkg/tools/result_test.go
@@ -88,3 +88,9 @@ func checkFile(assert *assert.Assertions, h *http.Request, name string, fn func(
 		fn(assert, f)
 	}
 }
+
+func TestIsMultiDocument(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(isMultiDocument("testdata/multi_document.yaml"))
+	assert.False(isMultiDocument("testdata/single_document.yaml"))
+}

--- a/pkg/tools/testdata/multi_document.yaml
+++ b/pkg/tools/testdata/multi_document.yaml
@@ -1,0 +1,4 @@
+---
+name: document one
+---
+name: document two

--- a/pkg/tools/testdata/single_document.yaml
+++ b/pkg/tools/testdata/single_document.yaml
@@ -1,0 +1,2 @@
+---
+name: the one and only

--- a/pkg/tools/toolopts.go
+++ b/pkg/tools/toolopts.go
@@ -49,6 +49,7 @@ type ToolOpts struct {
 	RepoRoot              string
 	PrintFingerprints     bool
 	SaveFingerprints      string
+	ConfigFile            string
 
 	customPoliciesDir *string
 	config            *Config
@@ -70,14 +71,18 @@ func (o *ToolOpts) GetConfig() *Config {
 
 func (o *ToolOpts) getConfig(repoRoot string) *Config {
 	if o.config == nil {
-		oldConfig := filepath.Join(repoRoot, ".soluble", "config.yml")
-		newConfig := filepath.Join(repoRoot, ".lacework", "config.yml")
-		if util.FileExists(oldConfig) && !util.FileExists(newConfig) {
-			log.Warnf("{info:%s} is {warning:deprecated}.  Use {info:%s} instead.",
-				oldConfig, newConfig)
-			o.config = ReadConfig(filepath.Join(repoRoot, ".soluble"))
+		if o.ConfigFile != "" {
+			o.config = ReadConfigFile(o.ConfigFile)
 		} else {
-			o.config = ReadConfig(filepath.Join(repoRoot, ".lacework"))
+			oldConfig := filepath.Join(repoRoot, ".soluble", "config.yml")
+			newConfig := filepath.Join(repoRoot, ".lacework", "config.yml")
+			if util.FileExists(oldConfig) && !util.FileExists(newConfig) {
+				log.Warnf("{info:%s} is {warning:deprecated}.  Use {info:%s} instead.",
+					oldConfig, newConfig)
+				o.config = ReadConfigFile(oldConfig)
+			} else {
+				o.config = ReadConfigFile(newConfig)
+			}
 		}
 	}
 	return o.config
@@ -95,6 +100,7 @@ func (o *ToolOpts) GetToolHiddenOptions() *options.HiddenOptionsGroup {
 			flags.StringVar(&o.SaveResultValues, "save-result-values", "", "Save the result values from the tool to `file`")
 			flags.BoolVar(&o.PrintFingerprints, "print-fingerprints", false, "Print fingerprints on stderr before uploading results")
 			flags.StringVar(&o.SaveFingerprints, "save-fingerprints", "", "Save finding fingerprints to `file`")
+			flags.StringVar(&o.ConfigFile, "config-file", "", "Read tool configuration from `file`, overriding the default config file search.")
 		},
 	}
 }

--- a/pkg/util/foreachline.go
+++ b/pkg/util/foreachline.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"bufio"
+	"os"
+)
+
+func ForEachLine(path string, fn func(line string) bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !fn(line) {
+			break
+		}
+	}
+	return sc.Err()
+}

--- a/pkg/util/foreachline_test.go
+++ b/pkg/util/foreachline_test.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForEachLine(t *testing.T) {
+	assert := assert.New(t)
+	var funcLine string
+	err := ForEachLine("foreachline.go", func(line string) bool {
+		if strings.HasPrefix(line, "func ForEachLine") {
+			funcLine = line
+		}
+		return true
+	})
+	assert.NoError(err)
+	assert.NotEmpty(funcLine)
+}


### PR DESCRIPTION
* Mark cdk findings as generated files

* Return error if helm-scan is run with no charts

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>