### PR TITLE
UX improvements

### DIFF
--- a/cmd/cfnscan/cfnscan.go
+++ b/cmd/cfnscan/cfnscan.go
@@ -23,11 +23,13 @@ import (
 )
 
 func Command() *cobra.Command {
-	c := tools.CreateCommand(&cfnpythonlint.Tool{})
+	c := tools.CreateCommand(&checkov.Tool{
+		Framework: "cloudformation",
+	})
 	c.Use = "cloudformation-scan"
 	c.Aliases = []string{"cfn-scan"}
 	c.Short = "Scan cloudformation templates"
-	c.Long = `Scan cloudformation templates with cfn-python-lint by default.
+	c.Long = `Scan cloudformation templates.
 
 Use the sub-commands to explicitly choose a scanner to use.`
 	c.AddCommand(

--- a/pkg/print/formatters.go
+++ b/pkg/print/formatters.go
@@ -196,3 +196,17 @@ func DurationMillisFormatter(n *jnode.Node) string {
 	d := time.Millisecond * time.Duration(val)
 	return formatDuration(d)
 }
+
+func TruncateFormatter(width int, left bool) Formatter {
+	return func(n *jnode.Node) string {
+		s := n.AsText()
+		if len(s) <= width {
+			return s
+		}
+		if left {
+			off := len(s) - width + 3
+			return fmt.Sprintf("...%s", s[off:])
+		}
+		return fmt.Sprintf("%s...", s[0:width-3])
+	}
+}

--- a/pkg/print/formatters_test.go
+++ b/pkg/print/formatters_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/soluble-ai/go-jnode"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatters(t *testing.T) {
@@ -112,4 +113,22 @@ func makeNode(val string, path ...string) *jnode.Node {
 	}
 	x.Put(path[len(path)-1], val)
 	return n
+}
+
+func TestTruncateFormatters(t *testing.T) {
+	var testCases = []struct {
+		fmt       Formatter
+		w         int
+		text, exp string
+	}{
+		{TruncateFormatter(10, false), 10, "hello world", "hello w..."},
+		{TruncateFormatter(10, true), 10, "hello world", "...o world"},
+		{TruncateFormatter(10, true), 10, "hello world and more", "...nd more"},
+	}
+	for _, c := range testCases {
+		n := jnode.NewObjectNode().Put("text", c.text)
+		exp := c.fmt(n.Path("text"))
+		assert.Equal(t, c.exp, exp, c.text)
+		assert.LessOrEqual(t, len(exp), c.w)
+	}
 }

--- a/pkg/tools/brakeman/brakeman.go
+++ b/pkg/tools/brakeman/brakeman.go
@@ -36,13 +36,16 @@ func (t *Tool) Name() string {
 
 func (t *Tool) Run() (*tools.Result, error) {
 	args := []string{"-f", "json", "-q"}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:                "brakeman",
 		Image:               "gcr.io/soluble-repo/soluble-brakeman:latest",
 		DefaultNoDockerName: "brakeman",
 		Directory:           t.GetDirectory(),
 		Args:                args,
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {

--- a/pkg/tools/bundler-audit/bundler-audit.go
+++ b/pkg/tools/bundler-audit/bundler-audit.go
@@ -35,13 +35,16 @@ func (t *Tool) Run() (*tools.Result, error) {
 	args := []string{
 		"check", "--quiet", "--format", "json", ".",
 	}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:                "bundler-audit",
 		Image:               "gcr.io/soluble-repo/soluble-bundler-audit:latest",
 		DefaultNoDockerName: "bundler-audit",
 		Directory:           t.GetDirectory(),
 		Args:                args,
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {

--- a/pkg/tools/cfn-python-lint/cfn-python-lint.go
+++ b/pkg/tools/cfn-python-lint/cfn-python-lint.go
@@ -54,13 +54,16 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no cloudformation templates found")
 	}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:                "cfn-python-lint",
 		DefaultNoDockerName: "cfn-lint",
 		Image:               "gcr.io/soluble-repo/soluble-cfn-lint:latest",
 		Directory:           t.GetDirectory(),
 		Args:                append([]string{"-f", "json"}, files...),
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {

--- a/pkg/tools/cfnnag/cfnnag.go
+++ b/pkg/tools/cfnnag/cfnnag.go
@@ -56,12 +56,15 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no cloudformation templates found")
 	}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:      "cfn_nag",
 		Image:     "stelligent/cfn_nag:latest",
 		Directory: t.GetDirectory(),
 		Args:      append([]string{"--output-format=json"}, files...),
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {

--- a/pkg/tools/command.go
+++ b/pkg/tools/command.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/soluble-ai/go-jnode"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
+	"github.com/soluble-ai/soluble-cli/pkg/print"
 	"github.com/spf13/cobra"
 )
 
@@ -79,6 +80,10 @@ func runTool(tool Interface) error {
 		// accumulate all the findings across the assessments.  So for the default
 		// or table output format we do that accumulation in code here.
 		if opts.OutputFormat == "" || opts.OutputFormat == "table" {
+			if !opts.Wide {
+				opts.SetFormatter("title", print.TruncateFormatter(70, false))
+				opts.SetFormatter("filePath", print.TruncateFormatter(65, true))
+			}
 			n, err = results.getFindingsJNode()
 		} else {
 			n, err = results.getAssessmentsJNode()

--- a/pkg/tools/diropts.go
+++ b/pkg/tools/diropts.go
@@ -139,6 +139,7 @@ func (o *DirectoryBasedToolOpts) Validate() error {
 		if err != nil {
 			return err
 		}
+		o.repoRootSet = true
 	}
 	if err := o.ToolOpts.Validate(); err != nil {
 		return err

--- a/pkg/tools/docker_test.go
+++ b/pkg/tools/docker_test.go
@@ -15,10 +15,29 @@
 package tools
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"testing"
 
+	"github.com/soluble-ai/soluble-cli/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNoDocker(t *testing.T) {
+	assert := assert.New(t)
+	assert.False(IsDockerError(nil))
+	assert.False(IsDockerError(fmt.Errorf("not a docker error")))
+	f, err := util.TempFile("docker*")
+	if assert.NoError(err) {
+		defer os.Remove(f)
+		err := hasDocker(func(c *exec.Cmd) {
+			c.Args = []string{"docker", "-H", fmt.Sprintf("unix://%s", f), "info"}
+		})
+		assert.Error(err)
+		assert.True(IsDockerError(err))
+	}
+}
 
 func TestDocker(t *testing.T) {
 	if hasDocker() == nil {

--- a/pkg/tools/hadolint/hadolint.go
+++ b/pkg/tools/hadolint/hadolint.go
@@ -36,13 +36,16 @@ func (t *Tool) Run() (*tools.Result, error) {
 	// This might be a problem if we have multiple dockerfiles and they have extensions like Dockerfile.xyz
 	dockerFilePath := "./Dockerfile"
 	args := []string{"hadolint", "-f", "json", "-", dockerFilePath}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:                "hadolint",
 		Image:               "ghcr.io/hadolint/hadolint:latest",
 		DefaultNoDockerName: "hadolint",
 		Directory:           t.GetDirectory(),
 		Args:                args,
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {

--- a/pkg/tools/npmaudit/npmaudit.go
+++ b/pkg/tools/npmaudit/npmaudit.go
@@ -35,13 +35,16 @@ func (t *Tool) Name() string {
 
 func (t *Tool) Run() (*tools.Result, error) {
 	args := []string{"audit", "--json"}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:                "npm-audit",
 		Image:               "gcr.io/soluble-repo/soluble-npm:latest",
 		DefaultNoDockerName: "npm",
 		Directory:           t.GetDirectory(),
 		Args:                args,
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {

--- a/pkg/tools/secrets/secrets.go
+++ b/pkg/tools/secrets/secrets.go
@@ -62,7 +62,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if customPoliciesDir != "" {
 		args = append(args, "--custom-plugins", customPoliciesDir)
 	}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:                "soluble-secrets",
 		DefaultNoDockerName: "detect-secrets",
 		Image:               "gcr.io/soluble-repo/soluble-secrets:latest",
@@ -70,6 +70,9 @@ func (t *Tool) Run() (*tools.Result, error) {
 		PolicyDirectory:     customPoliciesDir,
 		Args:                args,
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {

--- a/pkg/tools/semgrep/semgrep.go
+++ b/pkg/tools/semgrep/semgrep.go
@@ -91,7 +91,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 		PolicyDirectory: customPoliciesDir,
 		Args:            args,
 	})
-	if err != nil && util.ExitCode(err) != 1 {
+	if err != nil && (tools.IsDockerError(err) || util.ExitCode(err) != 1) {
 		// semgrep exits 1 if it finds issues
 		return nil, err
 	}

--- a/pkg/tools/toolopts.go
+++ b/pkg/tools/toolopts.go
@@ -53,6 +53,7 @@ type ToolOpts struct {
 
 	customPoliciesDir *string
 	config            *Config
+	repoRootSet       bool
 }
 
 var _ options.Interface = &ToolOpts{}
@@ -126,7 +127,7 @@ func (o *ToolOpts) Validate() error {
 		blurb.SignupBlurb(o, "This command requires signing up with {primary:Soluble} (unless --upload=false).", "")
 		return fmt.Errorf("not authenticated with Soluble")
 	}
-	if o.RepoRoot == "" {
+	if o.RepoRoot == "" && !o.repoRootSet {
 		r, err := inventory.FindRepoRoot(".")
 		if err != nil {
 			return err

--- a/pkg/tools/yarnaudit/yarnaudit.go
+++ b/pkg/tools/yarnaudit/yarnaudit.go
@@ -35,13 +35,16 @@ func (t *Tool) Name() string {
 
 func (t *Tool) Run() (*tools.Result, error) {
 	args := []string{"audit", "-s", "--json"}
-	d, _ := t.RunDocker(&tools.DockerTool{
+	d, err := t.RunDocker(&tools.DockerTool{
 		Name:                "yarn-audit",
 		Image:               "gcr.io/soluble-repo/soluble-yarn:latest",
 		DefaultNoDockerName: "yarn",
 		Directory:           t.GetDirectory(),
 		Args:                args,
 	})
+	if err != nil && tools.IsDockerError(err) {
+		return nil, err
+	}
 	results, err := jnode.FromJSON(d)
 	if err != nil {
 		if d != nil {


### PR DESCRIPTION
* Truncate title (on right) and filePath (on left) in tool report so
it doesn't get too wide (use --wide to disable.)

* Handle "docker unavailable" in tools.  (Tools have to check for
DockerError to distinguish between docker error and tool error.)

* Make checkov default for cfn-scan

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>