### PR TITLE
Add explicit support for terraform var files

### DIFF
--- a/cmd/test/tool.go
+++ b/cmd/test/tool.go
@@ -12,6 +12,7 @@ import (
 type Tool struct {
 	Command
 	Fingerprints     *jnode.Node
+	ExtraArgs        []string
 	fingerprintsFile string
 	upload           bool
 	dir              string
@@ -63,6 +64,10 @@ func (t *Tool) Run() error {
 	t.Args = append(t.Args, "--no-color", "--disable-custom-policies")
 	if t.dir != "" {
 		t.Args = append(t.Args, "-d", t.dir)
+	}
+	if len(t.ExtraArgs) > 0 {
+		t.Args = append(t.Args, "--")
+		t.Args = append(t.Args, t.ExtraArgs...)
 	}
 	if err := t.Command.Run(); err != nil {
 		return err

--- a/cmd/tfscan/integration/integration_test.go
+++ b/cmd/tfscan/integration/integration_test.go
@@ -34,3 +34,13 @@ func TestScanUploadJSON(t *testing.T) {
 	assert.NotEmpty(assmt.Path("assessmentId").AsText())
 	assert.Greater(assmt.Path("findings").Size(), 1)
 }
+
+func TestCheckovVarFile(t *testing.T) {
+	tool := test.NewTool(t, "tf-scan", "-d", "testdata", "--var-file", "testdata/pass.tfvars")
+	tool.ExtraArgs = []string{"--check", "CKV_AWS_20"}
+	tool.Must(tool.Run())
+	lines := strings.Split(tool.Out.String(), "\n")
+	if assert.Len(t, lines, 3) {
+		assert.Contains(t, lines[1], "PASS")
+	}
+}

--- a/cmd/tfscan/integration/testdata/main.tf
+++ b/cmd/tfscan/integration/testdata/main.tf
@@ -1,3 +1,20 @@
-resource "aws_instance" "instance" {
-    ebs_optimized = true
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "3.75.1"
+    }
+  }
+}
+
+provider "aws" {
+}
+
+variable "acl" {
+    default = "public-read"
+}
+
+resource "aws_s3_bucket" "test" {
+    bucket = "test"
+    acl = var.acl
 }

--- a/cmd/tfscan/integration/testdata/pass.tfvars
+++ b/cmd/tfscan/integration/testdata/pass.tfvars
@@ -1,0 +1,1 @@
+acl = "private"

--- a/pkg/print/filter_test.go
+++ b/pkg/print/filter_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestFilter(t *testing.T) {
-	row := jnode.NewObjectNode().Put("name", "value").Put("greeting", "hello")
+	row := jnode.NewObjectNode().Put("name", "value").Put("greeting", "hello").Put("fail", true)
 	if n := NewSingleFilter("hello").(*singleFilter); n.name != "" || n.g == nil || !n.Matches(row) {
 		t.Error(n)
 	}
@@ -47,6 +47,12 @@ func TestFilter(t *testing.T) {
 		t.Error(n)
 	}
 	if n := NewAndFilter([]string{"name=value", "greeting=hello"}); !n.Matches(row) {
+		t.Error(n)
+	}
+	if n := NewSingleFilter("pass=false"); !n.Matches(row) {
+		t.Error(n)
+	}
+	if n := NewSingleFilter("fail=true"); !n.Matches(row) {
 		t.Error(n)
 	}
 }

--- a/pkg/tools/checkov/checkov_test.go
+++ b/pkg/tools/checkov/checkov_test.go
@@ -17,6 +17,7 @@ package checkov
 import (
 	"testing"
 
+	"github.com/soluble-ai/soluble-cli/pkg/tools"
 	"github.com/soluble-ai/soluble-cli/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,4 +53,10 @@ func TestParseResults2(t *testing.T) {
 	assert.NoError(err)
 	result := tool.processResults(results)
 	assert.Equal("6", result.Values["RESOURCE_COUNT"])
+}
+
+func TestPropagateTfvarsEnv(t *testing.T) {
+	d := &tools.DockerTool{}
+	propagateTfVarsEnv(d, []string{"TF_VAR_foo=foo", "TF_VAR_bar=bar", "PATH=/bin;/usr/bin"})
+	assert.ElementsMatch(t, []string{"TF_VAR_foo", "TF_VAR_bar"}, d.PropagateEnvironmentVars)
 }

--- a/pkg/tools/diropts.go
+++ b/pkg/tools/diropts.go
@@ -128,7 +128,7 @@ func (o *DirectoryBasedToolOpts) Register(cmd *cobra.Command) {
 	o.ToolOpts.Register(cmd)
 	flags := cmd.Flags()
 	flags.StringVarP(&o.Directory, "directory", "d", "", "The directory to run in.")
-	flags.StringSliceVar(&o.Exclude, "exclude", nil, "Exclude results from file that match this glob pattern (path/**/foo.txt syntax supported.)  May be repeated.")
+	flags.StringSliceVar(&o.Exclude, "exclude", nil, "Exclude results from file that match this glob `pattern` (path/**/foo.txt syntax supported.)  May be repeated.")
 }
 
 func (o *DirectoryBasedToolOpts) Validate() error {

--- a/pkg/xcp/xcp_test.go
+++ b/pkg/xcp/xcp_test.go
@@ -23,6 +23,7 @@ import (
 func TestGetCIEnv(t *testing.T) {
 	saveEnv := os.Environ()
 	defer func() {
+		os.Clearenv()
 		for _, kv := range saveEnv {
 			eq := strings.Index(kv, "=")
 			os.Setenv(kv[0:eq], kv[eq+1:])


### PR DESCRIPTION
* Add flag --var-file to checkov scanner

* Refactor docker tool: remove PolicyDirectory and add more generate ExtraMounts

* Propagate TF_VAR_ environment variables to checkov when running n docker

* Let --filter pass=false work when the pass attribute is missing

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>