### PR TITLE
Always set tfsec version

### DIFF
--- a/cmd/test/require.go
+++ b/cmd/test/require.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/soluble-ai/soluble-cli/pkg/config"
@@ -8,12 +9,13 @@ import (
 
 func RequireAPIToken(t *testing.T) {
 	t.Helper()
-	if !HaveAPIToken() {
+	config.Load()
+	if config.Config.APIToken == "" {
 		t.Skip("test requires authentication")
 	}
-}
-
-func HaveAPIToken() bool {
-	config.Load()
-	return config.Config.APIToken != ""
+	if !strings.HasSuffix(config.Config.ProfileName, "-test") {
+		t.Log("Integration testing requires running with a profile that ends with -test")
+		t.Log("(You can copy an existing profile with \"... config new-profile --name demo-test --copy-from demo\")")
+		t.FailNow()
+	}
 }


### PR DESCRIPTION
* Use aquasecurity/tfsec instead of old tfsec/tfsec

* If we don't have the tfsec version run tfsec -v to get it

* Require integration test config profile to end with "-test"

* New command "download get-default-version"

* If "download install" doesn't have version, then get the default version

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>