### PR TITLE
Send git status -z output w/upload

### DIFF
--- a/cmd/tfscan/integration/integration_test.go
+++ b/cmd/tfscan/integration/integration_test.go
@@ -49,7 +49,8 @@ func TestScanUploadJSON(t *testing.T) {
 		files = append(files, f[slash+1:])
 	}
 	assert.ElementsMatch(files, []string{
-		"config.yml", "results.json", "tool.log", "findings.json", "fingerprints.json",
+		"config.yml", "results.json", "tool.log", "findings.json",
+		"fingerprints.json", "git-status-z.txt",
 	})
 }
 

--- a/pkg/tools/assessmentopts.go
+++ b/pkg/tools/assessmentopts.go
@@ -13,7 +13,7 @@ import (
 
 type AssessmentOpts struct {
 	ToolOpts
-	UploadOpt
+	UploadOpts
 	PrintResultOpt        bool
 	SaveResult            string
 	PrintResultValues     bool
@@ -36,7 +36,7 @@ func (o *AssessmentOpts) GetAssessmentOptions() *AssessmentOpts {
 func (o *AssessmentOpts) Register(c *cobra.Command) {
 	o.ToolOpts.Register(c)
 	o.DefaultUploadEnabled = true
-	o.UploadOpt.Register(c)
+	o.UploadOpts.Register(c)
 	o.SetFormatter("pass", PassFormatter)
 	// if not uploaded these columns will be empty, so make that a little easier to see
 	o.SetFormatter("sid", MissingFormatter)

--- a/pkg/tools/cloudmap/cloudmap.go
+++ b/pkg/tools/cloudmap/cloudmap.go
@@ -16,7 +16,7 @@ import (
 type Tool struct {
 	tools.ToolOpts
 	tools.DirectoryOpt
-	tools.UploadOpt
+	tools.UploadOpts
 	StateFile string
 
 	extraArgs tools.ExtraArgs
@@ -50,7 +50,7 @@ func (t *Tool) Validate() error {
 func (t *Tool) Register(cmd *cobra.Command) {
 	t.ToolOpts.Register(cmd)
 	t.DirectoryOpt.Register(cmd)
-	t.UploadOpt.Register(cmd)
+	t.UploadOpts.Register(cmd)
 	cmd.Flags().StringVar(&t.StateFile, "state-file", "", "Map resources from terraform state `file`")
 	t.Path = []string{"managed_resources"}
 	t.Columns = []string{"source_location.file", "source_location.line", "cloud_id"}

--- a/pkg/tools/iacinventory/local.go
+++ b/pkg/tools/iacinventory/local.go
@@ -30,7 +30,7 @@ import (
 type Local struct {
 	tools.ToolOpts
 	tools.DirectoryOpt
-	tools.UploadOpt
+	tools.UploadOpts
 }
 
 var _ tools.Simple = &Local{}
@@ -44,7 +44,7 @@ func (t *Local) Register(cmd *cobra.Command) {
 	t.ToolOpts.Register(cmd)
 	t.DirectoryOpt.Register(cmd)
 	t.DefaultUploadEnabled = true
-	t.UploadOpt.Register(cmd)
+	t.UploadOpts.Register(cmd)
 }
 
 func (t *Local) Validate() error {

--- a/pkg/tools/iacinventory/repo.go
+++ b/pkg/tools/iacinventory/repo.go
@@ -20,7 +20,7 @@ import (
 type Repo struct {
 	tools.ToolOpts
 	tools.DirectoryOpt
-	tools.UploadOpt
+	tools.UploadOpts
 	Details bool
 }
 
@@ -40,7 +40,7 @@ func (*Repo) CommandTemplate() *cobra.Command {
 func (r *Repo) Register(cmd *cobra.Command) {
 	r.ToolOpts.Register(cmd)
 	r.DirectoryOpt.Register(cmd)
-	r.UploadOpt.Register(cmd)
+	r.UploadOpts.Register(cmd)
 	flags := cmd.Flags()
 	flags.BoolVar(&r.Details, "details", false, "Print out the file tree along with a summary")
 }

--- a/pkg/tools/uploadopts_test.go
+++ b/pkg/tools/uploadopts_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGitPRDiffs(t *testing.T) {
 	assert := assert.New(t)
-	opts := &UploadOpt{
+	opts := &UploadOpts{
 		GitPRBaseRef: "HEAD~1",
 	}
 	dat := opts.getPRDIffText(".")


### PR DESCRIPTION
* Bug fix: use -z for git diff upload

* Use -z.txt to indicate null terminated fields: git-status-z.txt and
git-pr-diffs-z.txt

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>