### PR TITLE
style(internal): funcs to customize binary name/desc

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -64,8 +64,8 @@ var (
 func Command() *cobra.Command {
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd := &cobra.Command{
-		Use:           "soluble",
-		Long:          fmt.Sprintf(`Soluble CLI version %s`, v.Version),
+		Use:           binaryName(),
+		Long:          longName(),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -209,4 +209,25 @@ func mergeCommands(root, cmd *cobra.Command, m *model.Model) {
 		cmd.Short += " (" + m.Source.String() + ")"
 	}
 	root.AddCommand(cmd)
+}
+
+// ** Internal Use Only **
+//
+// To integrate the Soluble CLI into the Lacework CLI we are planning to add it as a
+// component (an extension) so that customers can discover and use it out-of-the-box.
+//
+// These functions will allow us to inject the name of the component at runtime so that
+// all the help messages reflect the correct component name. If the environment variable
+// does not exist, this funciton defaults to the original name of the Soluble CLI.
+func binaryName() string {
+	if name := os.Getenv("LW_COMPONENT_NAME"); name != "" {
+		return name
+	}
+	return "soluble"
+}
+func longName() string {
+	if name := os.Getenv("LW_COMPONENT_NAME"); name != "" {
+		return fmt.Sprintf(`%s version %s`, name, v.Version)
+	}
+	return fmt.Sprintf(`Soluble CLI version %s`, v.Version)
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -218,7 +218,7 @@ func mergeCommands(root, cmd *cobra.Command, m *model.Model) {
 //
 // These functions will allow us to inject the name of the component at runtime so that
 // all the help messages reflect the correct component name. If the environment variable
-// does not exist, this funciton defaults to the original name of the Soluble CLI.
+// does not exist, this function defaults to the original name of the Soluble CLI.
 func binaryName() string {
 	if name := os.Getenv("LW_COMPONENT_NAME"); name != "" {
 		return name


### PR DESCRIPTION
**Internal Use Only**

To integrate the Soluble CLI into the Lacework CLI we are planning to add it as a
component (an extension) so that customers can discover and use it out-of-the-box.

These functions will allow us to inject the name of the component at runtime so that
all the help messages reflect the correct component name. If the environment variable
does not exist, this function defaults to the original name of the Soluble CLI.

JIRA: https://lacework.atlassian.net/browse/RAIN-33521

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>