### PR TITLE
Small fixes

### DIFF
--- a/cmd/root/is_current_org.go
+++ b/cmd/root/is_current_org.go
@@ -1,0 +1,19 @@
+package root
+
+import (
+	"github.com/soluble-ai/go-jnode"
+	"github.com/soluble-ai/soluble-cli/pkg/config"
+	"github.com/soluble-ai/soluble-cli/pkg/model"
+)
+
+func isCurrentOrgFunction(n *jnode.Node) interface{} {
+	org := n.Path("orgId").AsText()
+	if org == config.Config.Organization {
+		return "*"
+	}
+	return ""
+}
+
+func init() {
+	model.RegisterColumnFunction("is_current_org", isCurrentOrgFunction)
+}

--- a/cmd/root/models/org.hcl
+++ b/cmd/root/models/org.hcl
@@ -8,7 +8,10 @@ command "group" "org" {
     path   = "org"
     result {
       path    = ["organizations"]
-      columns = ["displayName", "name", "orgId", "createTs", "isCurrent"]
+      columns = ["isCurrent", "displayName", "name", "orgId", "createTs"]
+      computed_columns = {
+        "isCurrent": "is_current_org"
+      }
     }
   }
   command "print_client" "update" {

--- a/pkg/policy/checkov/testdata/policies/checkov-py/s3_naming/terraform/rule.py
+++ b/pkg/policy/checkov/testdata/policies/checkov-py/s3_naming/terraform/rule.py
@@ -4,11 +4,8 @@ from typing import Dict, List, Any
 
 class S3Naming(BaseResourceCheck):
     def __init__(self):
-        name = "S3 bucket naming convention"
-        id = "ACME_CKV_002"
         supported_resources = ['aws_s3_bucket']
-        categories = [CheckCategories.CONVENTION]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+        super().__init__(name="", id="", categories=[], supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
         if 'bucket' in conf.keys():

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -151,7 +151,6 @@ func (m *Manager) ValidateRules() (ValidateMetrics, error) {
 		metrics ValidateMetrics
 		err     error
 	)
-
 	for _, ruleType := range m.getLoadedRuleTypes() {
 		rules := m.Rules[ruleType]
 		metrics.Count += len(rules)

--- a/pkg/print/formatters.go
+++ b/pkg/print/formatters.go
@@ -37,7 +37,7 @@ const (
 	mb = float64(int64(1) << 20)
 	gb = float64(int64(1) << 30)
 
-	RFC3339Millis   = "2006-01-02T15:04:05.999Z07:00"
+	RFC3339Millis   = "2006-01-02T15:04:05.000Z07:00"
 	GODefaultFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
 )
 

--- a/pkg/print/formatters_test.go
+++ b/pkg/print/formatters_test.go
@@ -34,7 +34,7 @@ func TestTimestampFormatters(t *testing.T) {
 	formatterNow = &now
 	formatterLocation = time.FixedZone("test", -8*60*60)
 	n := jnode.NewObjectNode().Put("ts", "2020-05-08T11:18:33Z")
-	if s := TimestampFormatter(n.Path("ts")); s != "2020-05-08T03:18:33-08:00" {
+	if s := TimestampFormatter(n.Path("ts")); s != "2020-05-08T03:18:33.000-08:00" {
 		t.Error("timestamp wrong", n, s)
 	}
 	if s := RelativeTimestampFormatter(n.Path("ts")); s != "2d22h47m12s" {

--- a/pkg/tools/assessmentopts.go
+++ b/pkg/tools/assessmentopts.go
@@ -114,7 +114,8 @@ func (o *AssessmentOpts) GetCustomPoliciesDir() (string, error) {
 	d, err := o.InstallAPIServerArtifact(fmt.Sprintf("%s-policies", o.Tool.Name()),
 		fmt.Sprintf("/api/v1/org/{org}/rules/%s/rules.tgz", o.Tool.Name()))
 	if err != nil {
-		return "", err
+		log.Warnf("Failed to get custom policies - {warning:%s}", err)
+		return "", nil
 	}
 	// if the directory is empty, then treat that the same as no custom policies
 	fs, err := ioutil.ReadDir(d.Dir)


### PR DESCRIPTION
* Just warn if custom policy doesn't unpack (for now, to be replaced)

* Fix "org list" to display current org

* Remove unecessary metadata from example checkov-py rule

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>