### PR TITLE
Remove old custom policy logic

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -118,7 +118,7 @@ func testCommand() *cobra.Command {
 		Use:   "test",
 		Short: "Test custom policy",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := m.DetectPolicy(); err != nil {
+			if err := m.DetectPolicy(""); err != nil {
 				return err
 			}
 			if _, err := m.ValidateRules(); err != nil {

--- a/pkg/policy/checkov/checkov_py_test.go
+++ b/pkg/policy/checkov/checkov_py_test.go
@@ -6,15 +6,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/soluble-ai/soluble-cli/pkg/policy"
 	"github.com/soluble-ai/soluble-cli/pkg/policy/manager"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPreparePy(t *testing.T) {
 	assert := assert.New(t)
-	m := &manager.M{Store: policy.Store{Dir: "testdata"}}
-	err := m.DetectPolicy()
+	m := &manager.M{}
+	err := m.DetectPolicy("testdata")
 	if !assert.NoError(err) {
 		return
 	}

--- a/pkg/policy/checkov/checkov_yaml_test.go
+++ b/pkg/policy/checkov/checkov_yaml_test.go
@@ -7,15 +7,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/soluble-ai/soluble-cli/pkg/policy"
 	"github.com/soluble-ai/soluble-cli/pkg/policy/manager"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
 
 func TestCheckov(t *testing.T) {
-	m := &manager.M{Store: policy.Store{Dir: "testdata"}}
-	err := m.DetectPolicy()
+	m := &manager.M{}
+	err := m.DetectPolicy("testdata")
 	assert.NoError(t, err)
 	assert.Len(t, m.Rules[CheckovYAML], 1)
 	rule := m.Rules[CheckovYAML][0]

--- a/pkg/policy/checkov/detect_test.go
+++ b/pkg/policy/checkov/detect_test.go
@@ -13,8 +13,8 @@ func TestDetectPolicy(t *testing.T) {
 		"testdata", "testdata/policies", "testdata/policies/checkov",
 		"testdata/policies/checkov/team_tag/terraform",
 	} {
-		m := &manager.M{Store: policy.Store{Dir: dir}}
-		err := m.DetectPolicy()
+		m := &manager.M{}
+		err := m.DetectPolicy(dir)
 		assertFoundRule(t, m, dir, err)
 	}
 }

--- a/pkg/policy/manager/detect.go
+++ b/pkg/policy/manager/detect.go
@@ -20,7 +20,10 @@ import (
 // policies/<rule-type>/<rule>/<target>
 //
 // <target> is optional depending on <rule-type>.
-func (m *M) DetectPolicy() error {
+func (m *M) DetectPolicy(dir string) error {
+	if dir != "" {
+		m.Dir = dir
+	}
 	if !filepath.IsAbs(m.Dir) {
 		dir, err := filepath.Abs(m.Dir)
 		if err != nil {

--- a/pkg/policy/manager/manager.go
+++ b/pkg/policy/manager/manager.go
@@ -110,7 +110,7 @@ tests:
 		opts := tool.GetAssessmentOptions()
 		opts.Tool = tool
 		opts.DisableCustomPolicies = true
-		opts.CustomPoliciesDir = dest
+		opts.PreparedCustomPoliciesDir = dest
 		opts.UploadEnabled = false
 		if dir, ok := tool.(tools.HasDirectory); ok {
 			dir.SetDirectory(testDir)

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -178,7 +178,7 @@ func (m *Store) writeUploadMetadata(w *tar.Writer) error {
 	}
 	h := &tar.Header{
 		Typeflag: tar.TypeReg,
-		Name:     "policies/upload.json",
+		Name:     "policies-upload-metadata.json",
 		Size:     int64(len(dat)),
 		ModTime:  time.Now(),
 		Mode:     0644,
@@ -278,6 +278,27 @@ func (m *Store) writeRuleFiles(w *tar.Writer, rule *Rule) error {
 		}
 		return nil
 	})
+}
+
+func (m *Store) GetPolicyUploadMetadata() (map[string]string, error) {
+	dat, err := os.ReadFile(filepath.Join(m.Dir, "policies-upload-metadata.json"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var md map[string]interface{}
+	if err := json.Unmarshal(dat, &md); err != nil {
+		return nil, err
+	}
+	res := map[string]string{}
+	for k, v := range md {
+		if s, ok := v.(string); ok {
+			res[k] = s
+		}
+	}
+	return res, err
 }
 
 func GetRuleTypes() (res []RuleType) {

--- a/pkg/tools/assessment.go
+++ b/pkg/tools/assessment.go
@@ -55,6 +55,9 @@ func processResult(result *Result) error {
 		}
 	}
 	result.AddValues(result.Tool.GetToolOptions().GetStandardXCPValues())
+	if len(o.customPolicyMetadata) > 0 {
+		addCustomPolicyMetadata(result, o.customPolicyMetadata)
+	}
 	if result.Directory != "" {
 		result.UpdateFileFingerprints()
 		if result.Values[AssessmentDirectoryValue] == "" {
@@ -133,5 +136,11 @@ func processResult(result *Result) error {
 func writeResultValues(w io.Writer, result *Result) {
 	for k, v := range result.Values {
 		fmt.Fprintf(w, "%s=%s\n", k, v)
+	}
+}
+
+func addCustomPolicyMetadata(result *Result, metadata map[string]string) {
+	for k, v := range metadata {
+		result.AddValue(fmt.Sprintf("CUSTOM_POLICY_%s", k), v)
 	}
 }


### PR DESCRIPTION
* Allow --custom-policies to point to custom policy source dir

* Internally, allow PreparedCustomPoliciesDir to for prepared policies

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>