### PR TITLE
Don't require a package declaration in opal rules

### DIFF
--- a/pkg/policy/opal/rule_text_test.go
+++ b/pkg/policy/opal/rule_text_test.go
@@ -58,3 +58,21 @@ func TestQuote(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal(`"hello"`, regoQuote("hello"))
 }
+
+func TestReadNoPackage(t *testing.T) {
+	assert := assert.New(t)
+	r, err := readRuleText("testdata/rule-no-package.rego")
+	assert.NoError(err)
+	if !assert.NotNil(r) {
+		return
+	}
+	b := &strings.Builder{}
+	assert.NoError(r.write(b, policy.Metadata{
+		"sid": "c-opl-test-no-package",
+	}))
+	s := b.String()
+	fmt.Println(s)
+	dat, err := os.ReadFile("testdata/rule-no-package-rewrite.rego")
+	assert.NoError(err)
+	assert.Equal(string(dat), s)
+}

--- a/pkg/policy/opal/testdata/rule-no-package-rewrite.rego
+++ b/pkg/policy/opal/testdata/rule-no-package-rewrite.rego
@@ -1,0 +1,13 @@
+package rules.c_opl_test_no_package
+
+__rego__metadoc__ := {
+  "id": "c-opl-test-no-package"
+}
+
+default allow = false
+
+resource_type := "aws_ebs_volume"
+
+allow {
+    input.encrypted == true
+}

--- a/pkg/policy/opal/testdata/rule-no-package.rego
+++ b/pkg/policy/opal/testdata/rule-no-package.rego
@@ -1,0 +1,7 @@
+default allow = false
+
+resource_type := "aws_ebs_volume"
+
+allow {
+    input.encrypted == true
+}


### PR DESCRIPTION
Signed-off-by: Sam Shen <slshen@users.noreply.github.com>