### PR TITLE
Support kubernetes, cloudformation, and arm scans with opal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Installing golangci-lint
-      run: wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.42.1
+      run: wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.48.0
     - name: Build and Test
       run: ./hack/build.sh
       env:

--- a/cmd/armscan/armscan.go
+++ b/cmd/armscan/armscan.go
@@ -17,6 +17,7 @@ package armscan
 import (
 	"github.com/soluble-ai/soluble-cli/pkg/tools"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/checkov"
+	"github.com/soluble-ai/soluble-cli/pkg/tools/opal"
 	"github.com/spf13/cobra"
 )
 
@@ -34,5 +35,8 @@ Use the sub-commands to explicitly choose a scanner to use.`
 	})
 	ckv.Short = "Scan ARM templates with checkov"
 	c.AddCommand(ckv)
+	c.AddCommand(tools.CreateCommand(&opal.Tool{
+		IACPlatform: tools.ARM,
+	}))
 	return c
 }

--- a/cmd/cfnscan/cfnscan.go
+++ b/cmd/cfnscan/cfnscan.go
@@ -19,6 +19,7 @@ import (
 	cfnpythonlint "github.com/soluble-ai/soluble-cli/pkg/tools/cfn-python-lint"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/cfnnag"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/checkov"
+	"github.com/soluble-ai/soluble-cli/pkg/tools/opal"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +38,9 @@ Use the sub-commands to explicitly choose a scanner to use.`
 		tools.CreateCommand(&cfnpythonlint.Tool{}),
 		tools.CreateCommand(&checkov.Tool{
 			Framework: "cloudformation",
+		}),
+		tools.CreateCommand(&opal.Tool{
+			IACPlatform: tools.Cloudformation,
 		}),
 	)
 	return c

--- a/cmd/k8sscan/k8sscan.go
+++ b/cmd/k8sscan/k8sscan.go
@@ -17,6 +17,7 @@ package k8sscan
 import (
 	"github.com/soluble-ai/soluble-cli/pkg/tools"
 	"github.com/soluble-ai/soluble-cli/pkg/tools/checkov"
+	"github.com/soluble-ai/soluble-cli/pkg/tools/opal"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +26,11 @@ func Command() *cobra.Command {
 	c.Use = "kubernetes-scan"
 	c.Short = "Scan kubernetes manifests"
 	c.Aliases = []string{"k8s-scan"}
-	c.AddCommand(tools.CreateCommand(&checkov.Kubernetes{}))
+	c.AddCommand(
+		tools.CreateCommand(&checkov.Kubernetes{}),
+		tools.CreateCommand(&opal.Tool{
+			IACPlatform: tools.Kubernetes,
+		}),
+	)
 	return c
 }

--- a/pkg/archive/tarball_test.go
+++ b/pkg/archive/tarball_test.go
@@ -16,7 +16,6 @@ package archive
 
 import (
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -52,7 +51,7 @@ func TestTarball(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	c, _ := ioutil.ReadAll(f)
+	c, _ := io.ReadAll(f)
 	if string(c) != "hello, world\n" {
 		t.Error("bad content")
 	}

--- a/pkg/archive/untar_test.go
+++ b/pkg/archive/untar_test.go
@@ -15,7 +15,6 @@
 package archive
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,7 +54,7 @@ func TestUntarTruncate(t *testing.T) {
 }
 
 func TestUntarSymlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "testuntar*")
+	dir, err := os.MkdirTemp("", "testuntar*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/archive/unzip_test.go
+++ b/pkg/archive/unzip_test.go
@@ -17,7 +17,7 @@ package archive
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,7 +49,7 @@ func TestUnzipTruncate(t *testing.T) {
 }
 
 func TestUnzipTree(t *testing.T) {
-	dir, err := ioutil.TempDir("", "unziptree*")
+	dir, err := os.MkdirTemp("", "unziptree*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func assertFileEquals(fs afero.Fs, path, content string) error {
 		return err
 	}
 	defer in.Close()
-	dat, err := ioutil.ReadAll(in)
+	dat, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -253,7 +252,7 @@ func Load() {
 	if configFileRead == "" {
 		configFileRead = ConfigFile
 	}
-	dat, err := ioutil.ReadFile(configFileRead)
+	dat, err := os.ReadFile(configFileRead)
 	if err != nil {
 		configFileRead = ""
 	} else {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -25,7 +24,7 @@ import (
 
 func TestConfig(t *testing.T) {
 	assert := assert.New(t)
-	f, err := ioutil.TempFile("", "config")
+	f, err := os.CreateTemp("", "config")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -118,7 +117,7 @@ func (m *Manager) List() (result []*DownloadMeta) {
 			_, file := filepath.Split(r)
 			if file == "meta.json" {
 				var m DownloadMeta
-				data, err := ioutil.ReadFile(path)
+				data, err := os.ReadFile(path)
 				if err == nil {
 					if json.Unmarshal(data, &m) == nil {
 						result = append(result, &m)

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -16,7 +16,6 @@ package download
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -108,7 +107,7 @@ func TestAPIServerArtifact(t *testing.T) {
 
 func setupManager() *Manager {
 	m := NewManager()
-	dir, err := ioutil.TempDir("", "downloadtest*")
+	dir, err := os.MkdirTemp("", "downloadtest*")
 	if err != nil {
 		panic(err)
 	}
@@ -125,7 +124,7 @@ func setupHTTP() {
 }
 
 func registerTestArchive(name string, auth bool) {
-	dat, err := ioutil.ReadFile(filepath.Join("testdata", name))
+	dat, err := os.ReadFile(filepath.Join("testdata", name))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/login/callback.go
+++ b/pkg/login/callback.go
@@ -17,7 +17,7 @@ package login
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 
@@ -57,6 +57,7 @@ or using those ports.
 
 func (e *callbackEndpoint) serveOne() <-chan *jnode.Node {
 	e.r = make(chan *jnode.Node)
+	// #nosec:G112
 	e.s = &http.Server{
 		Handler: http.HandlerFunc(e.handleAuth),
 	}
@@ -82,7 +83,7 @@ func (e *callbackEndpoint) handleAuth(w http.ResponseWriter, req *http.Request) 
 	w.Header().Add("Access-Control-Max-Age", "600")
 	w.Header().Add("Content-type", "text/plain")
 	if req.Method == "POST" {
-		dat, err := ioutil.ReadAll(req.Body)
+		dat, err := io.ReadAll(req.Body)
 		if err != nil {
 			log.Errorf("Could not read oauth response: {danger:%s}", err.Error())
 			e.r <- nil

--- a/pkg/login/flow.go
+++ b/pkg/login/flow.go
@@ -17,7 +17,7 @@ package login
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -74,7 +74,7 @@ func (f *Flow) Run() (*Response, error) {
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
 	}
-	dat, err := ioutil.ReadAll(resp.Body)
+	dat, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("garbled response: %w", err)
 	}

--- a/pkg/model/git_source_test.go
+++ b/pkg/model/git_source_test.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestGitSource(t *testing.T) {
 	root, err := repotree.FindRepoRoot(".")
 	util.Must(err)
 	saveDir := config.ConfigDir
-	config.ConfigDir, err = ioutil.TempDir("", "test-git-source*")
+	config.ConfigDir, err = os.MkdirTemp("", "test-git-source*")
 	util.Must(err)
 	defer func() { _ = os.RemoveAll(config.ConfigDir); config.ConfigDir = saveDir }()
 	assert := assert.New(t)

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -16,8 +16,8 @@ package model
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -108,7 +108,7 @@ func (m *modelLoader) loadModel(source Source, name string) error {
 		return err
 	}
 	defer f.Close()
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/tools/assessmentopts.go
+++ b/pkg/tools/assessmentopts.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/soluble-ai/soluble-cli/pkg/assessments"
@@ -125,7 +124,7 @@ func (o *AssessmentOpts) GetCustomPoliciesDir() (string, error) {
 		dir = d.Dir
 	}
 	// if the directory is empty, then treat that the same as no custom policies
-	fs, err := ioutil.ReadDir(dir)
+	fs, err := os.ReadDir(dir)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/tools/checkov/cdk.go
+++ b/pkg/tools/checkov/cdk.go
@@ -96,7 +96,7 @@ func (cdk *CDK) Run() (*tools.Result, error) {
 	}
 	if result != nil {
 		result.ModuleName = "checkov-cdk"
-		result.IACPlatform = "cdk"
+		result.IACPlatform = tools.CDK
 	}
 	return result, err
 }

--- a/pkg/tools/checkov/checkov.go
+++ b/pkg/tools/checkov/checkov.go
@@ -173,7 +173,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 	}
 	result := exec.ToResult(t.GetDirectory())
 	result.ModuleName = "checkov"
-	result.IACPlatform = strings.ReplaceAll(t.Framework, "_", "-")
+	result.IACPlatform = tools.IACPlatform(strings.ReplaceAll(t.Framework, "_", "-"))
 	if !exec.ExpectExitCode(0) {
 		return result, nil
 	}

--- a/pkg/tools/checkov/helm.go
+++ b/pkg/tools/checkov/helm.go
@@ -78,7 +78,7 @@ func (h *Helm) Run() (*tools.Result, error) {
 	}
 	result, err := checkov.Run()
 	if result != nil {
-		result.IACPlatform = "helm"
+		result.IACPlatform = tools.Helm
 	}
 	return result, err
 }

--- a/pkg/tools/checkov/kustomize.go
+++ b/pkg/tools/checkov/kustomize.go
@@ -77,7 +77,7 @@ func (k *Kustomize) Run() (*tools.Result, error) {
 	}
 	result, err := checkov.Run()
 	if result != nil {
-		result.IACPlatform = "kustomize"
+		result.IACPlatform = tools.Kustomize
 	}
 	return result, err
 }

--- a/pkg/tools/cloudsploit/cloudsploit.go
+++ b/pkg/tools/cloudsploit/cloudsploit.go
@@ -17,7 +17,6 @@ package cloudsploit
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -70,7 +69,7 @@ func Command() *cobra.Command {
 func writeEnvFile(env map[string]string) (string, error) {
 	// Write the environment variables to a tmpdir with a bindmount
 	// (because we don't want to leak sensitive keys into `ps` and logs)
-	envFile, err := ioutil.TempFile("", "soluble-cloudsploit*")
+	envFile, err := os.CreateTemp("", "soluble-cloudsploit*")
 	if err != nil {
 		return "", fmt.Errorf("unable to create temporary file for cloudsploit: %w", err)
 	}

--- a/pkg/tools/config.go
+++ b/pkg/tools/config.go
@@ -16,7 +16,6 @@ package tools
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/soluble-ai/go-jnode"
@@ -31,7 +30,7 @@ type Config struct {
 
 func ReadConfigFile(path string) *Config {
 	c := &Config{}
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			log.Warnf("Could not read {warning:%s} - {warning:%s}", path, err)

--- a/pkg/tools/diropts_test.go
+++ b/pkg/tools/diropts_test.go
@@ -15,7 +15,6 @@
 package tools
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func TestDirectoryOpts(t *testing.T) {
 
 func TestNoRepo(t *testing.T) {
 	assert := assert.New(t)
-	dir, err := ioutil.TempDir("", "soluble-cli*")
+	dir, err := os.MkdirTemp("", "soluble-cli*")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 	o := &DirectoryBasedToolOpts{

--- a/pkg/tools/result.go
+++ b/pkg/tools/result.go
@@ -33,6 +33,20 @@ import (
 	"github.com/soluble-ai/soluble-cli/pkg/xcp"
 )
 
+type IACPlatform string
+
+const (
+	Terraform      = IACPlatform("terraform")
+	TerraformPlan  = IACPlatform("terraform_plan")
+	CDK            = IACPlatform("cdk")
+	Helm           = IACPlatform("helm")
+	Kustomize      = IACPlatform("kustomize")
+	Cloudformation = IACPlatform("cloudformation")
+	Dockerfile     = IACPlatform("dockerfile")
+	ARM            = IACPlatform("arm")
+	Kubernetes     = IACPlatform("kubernetes")
+)
+
 type Result struct {
 	Tool             Single
 	Data             *jnode.Node
@@ -43,7 +57,7 @@ type Result struct {
 	UploadOptions    []api.Option
 	ExecuteResult    *ExecuteResult
 	ModuleName       string
-	IACPlatform      string
+	IACPlatform      IACPlatform
 
 	Assessment    *assessments.Assessment
 	AssessmentRaw *jnode.Node
@@ -101,7 +115,7 @@ func (r *Result) upload(client *api.Client, org, name string, compressFiles bool
 	}
 	values := r.Values
 	if r.IACPlatform != "" {
-		values["IAC_PLATFORM"] = r.IACPlatform
+		values["IAC_PLATFORM"] = string(r.IACPlatform)
 	}
 	dir, _ := repotree.FindRepoRoot(r.Directory)
 	if dir != "" {

--- a/pkg/tools/result_test.go
+++ b/pkg/tools/result_test.go
@@ -15,7 +15,6 @@
 package tools
 
 import (
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -43,7 +42,7 @@ func createFile(dir, path, content string) {
 
 func TestUpload(t *testing.T) {
 	assert := assert.New(t)
-	tempdir, _ := ioutil.TempDir("", "toolopt*")
+	tempdir, _ := os.MkdirTemp("", "toolopt*")
 	defer os.RemoveAll(tempdir)
 	createFile(tempdir, filepath.FromSlash(".soluble/config.yml"), "# config.yml\n")
 	createFile(tempdir, filepath.FromSlash(".git/config"), "# .git/config\n")

--- a/pkg/tools/temp.go
+++ b/pkg/tools/temp.go
@@ -15,13 +15,12 @@
 package tools
 
 import (
-	"io/ioutil"
 	"os"
 )
 
 func TempFile(pattern string) (name string, err error) {
 	var f *os.File
-	f, err = ioutil.TempFile("", pattern)
+	f, err = os.CreateTemp("", pattern)
 	if err != nil {
 		return
 	}

--- a/pkg/tools/tfsec/tfsec.go
+++ b/pkg/tools/tfsec/tfsec.go
@@ -66,7 +66,7 @@ func (t *Tool) Register(cmd *cobra.Command) {
 func (t *Tool) Run() (*tools.Result, error) {
 	result := &tools.Result{
 		Directory:   t.GetDirectory(),
-		IACPlatform: "terraform",
+		IACPlatform: tools.Terraform,
 	}
 	if !t.NoInit {
 		tfInit, err := t.runTerraformInit()

--- a/pkg/tools/trivy/trivy.go
+++ b/pkg/tools/trivy/trivy.go
@@ -15,7 +15,6 @@
 package trivy
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -85,7 +84,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 		return nil, err
 	}
 
-	dat, err := ioutil.ReadFile(outfile)
+	dat, err := os.ReadFile(outfile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tools/trivyfs/trivyfs.go
+++ b/pkg/tools/trivyfs/trivyfs.go
@@ -15,7 +15,6 @@
 package trivyfs
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -73,7 +72,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if !exec.ExpectExitCode(0) {
 		return result, nil
 	}
-	dat, err := ioutil.ReadFile(outfile)
+	dat, err := os.ReadFile(outfile)
 	if err != nil {
 		exec.SetFailureFromError(tools.GarbledResultFailure, err)
 		return result, nil

--- a/pkg/util/close_test.go
+++ b/pkg/util/close_test.go
@@ -16,7 +16,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -33,7 +33,7 @@ func (ec *errorCloser) Close() error {
 func TestCloseAll(t *testing.T) {
 	ec2 := &errorCloser{"second", false}
 	ec3 := &errorCloser{"third", false}
-	err := CloseAll(ioutil.NopCloser(nil), ec2, ec3)
+	err := CloseAll(io.NopCloser(nil), ec2, ec3)
 	if err == nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* Remove ioutil deprecation warnings

* Upgrade to golangci-lint 1.48.0

* Add var files support to opal

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>