### PR TITLE
fix(RAIN-36252) Replace all output formats other than JSON from opal

### DIFF
--- a/cmd/tfscan/integration/integration_test.go
+++ b/cmd/tfscan/integration/integration_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -90,4 +91,11 @@ func TestTfsec(t *testing.T) {
 	tool.Must(tool.Run())
 	n := tool.JSON()
 	assert.Greater(n.Get(0).Path("findings").Size(), 1)
+}
+
+func TestOpalDefaultOutputFormat(t *testing.T) {
+	assert := assert.New(t)
+	tool := test.NewTool(t, "tf-scan", "opal", "-d", "testdata", "--use-empty-config-file")
+	tool.Must(tool.Run())
+	assert.True(json.Valid([]byte(tool.Out.String())))
 }

--- a/pkg/tools/opal/opal.go
+++ b/pkg/tools/opal/opal.go
@@ -77,7 +77,7 @@ func (t *Tool) Validate() error {
 		t.OutputFormat = "json"
 
 	} else if t.OutputFormat != "json" {
-		return fmt.Errorf("Opal supports json output format only")
+		return fmt.Errorf("opal supports json output format only")
 	}
 
 	return t.DirectoryBasedToolOpts.Validate()

--- a/pkg/tools/opal/opal.go
+++ b/pkg/tools/opal/opal.go
@@ -72,6 +72,14 @@ func (t *Tool) Validate() error {
 			return fmt.Errorf("var file %s does not exist", varFile)
 		}
 	}
+
+	if t.OutputFormat == "" {
+		t.OutputFormat = "json"
+
+	} else if t.OutputFormat != "json" {
+		return fmt.Errorf("Opal supports json output format only")
+	}
+
 	return t.DirectoryBasedToolOpts.Validate()
 }
 


### PR DESCRIPTION
Signed-off-by: Ellie <ellie.goggin@lacework.net>

### Linked Jira
> https://lacework.atlassian.net/browse/RAIN-36252

### Description
> Opal only needs to support json format.

### Tests Added
> Added test to ensure default format is json