### PR TITLE
Use the profile API rather than the /api/v1/org API which no longer works

### DIFF
--- a/cmd/root/models/org.hcl
+++ b/cmd/root/models/org.hcl
@@ -8,7 +8,7 @@ command "group" "org" {
     path   = "users/profile"
     result {
       path    = ["data", "organizations"]
-      columns = ["isCurrent", "displayName", "name", "orgId", "active", "createTs"]
+      columns = ["isCurrent", "displayName", "name", "orgId", "active"]
       computed_columns = {
         "isCurrent": "is_current_org"
       }

--- a/cmd/root/models/org.hcl
+++ b/cmd/root/models/org.hcl
@@ -5,10 +5,10 @@ command "group" "org" {
   command "print_client" "list" {
     short  = "List your organizations"
     method = "GET"
-    path   = "org"
+    path   = "users/profile"
     result {
-      path    = ["organizations"]
-      columns = ["isCurrent", "displayName", "name", "orgId", "createTs"]
+      path    = ["data", "organizations"]
+      columns = ["isCurrent", "displayName", "name", "orgId", "active", "createTs"]
       computed_columns = {
         "isCurrent": "is_current_org"
       }


### PR DESCRIPTION
Signed-off-by: Hemanth Gokavarapu <hemanth@soluble.ai>

## JIRA TICKET
https://lacework.atlassian.net/browse/RAIN-38295

## DESCRIPTION
The old API no longer works after the JWT token refactor and should be use the profile information which is more accurate.

```
$ ./soluble-cli org list                                                                                                             
[ Info] GET https://api.demo.soluble.cloud/api/v1/users/profile returned 200 in 517ms
IS-CURRENT DISPLAY-NAME NAME        ORG-ID       ACTIVE 
                       soluble-ai   <nil>       192593697731        true
                       hemanthgk10  hemanthgk10 457749446932 true
            *          InsecureCorp <nil>       516676385582 true
```