### PR TITLE
feat(RAIN-38892): lacework cli components dev build trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,4 +56,14 @@ jobs:
       run: ./hack/dist.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+    - name: lwcomponents
+      run: |
+        if [[ "${GITHUB_REF_TYPE}" = "tag" ]]; then
+          TAG_NAME=$(echo ${GITHUB_REF} | awk -F/ '{ print $3 }')
+          curl \
+            -X POST \
+            -H "Authorization: token ${{ secrets.LW_DEV_CLI_COMPONENTS_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/lacework-dev/soluble-cli/actions/workflows/main.yaml/dispatches \
+            -d '{"ref":"main", "inputs": {"src_repo":"soluble-ai/soluble-cli", "tag_version":"'"${TAG_NAME}"'"} }'
+        fi


### PR DESCRIPTION
If a published release with tagging event, run an additional step to invoke a Lacework CLI dev-only, component building workflow for build/publishing of this soluble cli as a component.

Signed-off-by: Declan Wilson <declan.wilson@lacework.net>