### PR TITLE
fix(RAIN-38965) policy download does not work using lacework auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target/
 .terraform*
 .helm*
 .kustomize*
+/.external_modules/

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -84,7 +84,9 @@ type apiServer string
 
 func (apiServer) GetOrganization() string { return "9999" }
 func (apiServer) GetHostURL() string      { return "https://example.com/secure" }
-func (a apiServer) GetAuthToken() string  { return string(a) }
+func (a apiServer) ConfigureAuthHeaders(headers http.Header) {
+	headers.Set("Authorization", fmt.Sprintf("Bearer %s", string(a)))
+}
 
 func TestAPIServerArtifact(t *testing.T) {
 	setupHTTP()

--- a/pkg/download/options.go
+++ b/pkg/download/options.go
@@ -17,10 +17,3 @@ package download
 import "net/http"
 
 type downloadOption func(req *http.Request) error
-
-func withBearerToken(token string) downloadOption {
-	return func(req *http.Request) error {
-		req.Header.Set("Authorization", "Bearer "+token)
-		return nil
-	}
-}

--- a/pkg/options/client_opts.go
+++ b/pkg/options/client_opts.go
@@ -126,6 +126,7 @@ func (opts *ClientOpts) GetUnauthenticatedAPIClient() *api.Client {
 	if opts.unauthClient == nil {
 		cfg, _ := opts.GetAPIClientConfig()
 		cfg.APIToken = ""
+		cfg.LaceworkAPIToken = ""
 		cfg.Domain = ""
 		opts.unauthClient = api.NewClient(cfg)
 	}


### PR DESCRIPTION
* download sets the correct headers when using lacework auth

* fix: getting an unauth client wipes out auth headers

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>