### PR TITLE
feat(RAIN-38723) retry support

### DIFF
--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -29,6 +29,7 @@ func TestClient(t *testing.T) {
 	})
 	c.Organization = "1234"
 	httpmock.ActivateNonDefault(c.Client.GetClient())
+	t.Cleanup(httpmock.Deactivate)
 	httpmock.RegisterResponder("GET", "https://api.soluble.cloud/api/v1/org/1234/foo",
 		httpmock.NewJsonResponderOrPanic(http.StatusOK,
 			jnode.NewObjectNode().Put("hello", "world")),

--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/soluble-ai/soluble-cli/pkg/log"
+)
+
+type logger int
+
+var _ resty.Logger = logger(0)
+
+func (logger) Debugf(message string, args ...interface{}) {
+	log.Debugf(message, args...)
+}
+
+func (logger) Errorf(message string, args ...interface{}) {
+	log.Errorf(message, args...)
+}
+
+func (logger) Warnf(message string, args ...interface{}) {
+	log.Warnf(message, args...)
+}

--- a/pkg/api/retry_test.go
+++ b/pkg/api/retry_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetry(t *testing.T) {
+	assert := assert.New(t)
+	c := NewClient(&Config{
+		APIServer:        "https://api.soluble.cloud",
+		RetryCount:       3,
+		RetryWaitSeconds: 0.1,
+	})
+	c.Organization = "1234"
+	httpmock.ActivateNonDefault(RClient.GetClient())
+	httpmock.ZeroCallCounters()
+	t.Cleanup(httpmock.Deactivate)
+	count := 2
+	httpmock.RegisterResponder("GET", "https://api.soluble.cloud/api/v1/org/1234/foo",
+		func(r *http.Request) (*http.Response, error) {
+			count--
+			if count == 0 {
+				return httpmock.NewJsonResponse(200, map[string]interface{}{"message": "ok"})
+			}
+			return httpmock.NewJsonResponse(502, map[string]interface{}{
+				"message": "not working",
+			})
+		})
+	n, err := c.Get("org/1234/foo")
+	assert.NoError(err)
+	assert.NotNil(n)
+	assert.Equal(2, httpmock.GetTotalCallCount())
+}


### PR DESCRIPTION
* Retry api calls on 5xx status codes if --api-retry is given

* Note --api-retry 5 --api-retry-wait 1 gives about 30 seconds of retries

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>