### PR TITLE
Make retry work on downloading policies

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/soluble-ai/go-jnode"
+	"github.com/soluble-ai/soluble-cli/pkg/api"
 	"github.com/soluble-ai/soluble-cli/pkg/config"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/options"
@@ -13,6 +14,7 @@ import (
 type configureCommand struct {
 	options.PrintClientOpts
 	laceworkProfileName string
+	clientHook          func(*api.Client) // for testing only
 }
 
 func (c *configureCommand) Register(cmd *cobra.Command) {
@@ -58,6 +60,9 @@ func (c *configureCommand) Run() (*jnode.Node, error) {
 	api, err := c.GetAPIClient()
 	if err != nil {
 		return nil, err
+	}
+	if c.clientHook != nil {
+		c.clientHook(api)
 	}
 	if api.LaceworkAPIToken == "" {
 		return nil, fmt.Errorf("lacework CLI configuration is missing, run 'lacework configure' first")

--- a/cmd/configure/configure_test.go
+++ b/cmd/configure/configure_test.go
@@ -17,7 +17,7 @@ import (
 
 func setupTest(t *testing.T, assertions func(r *http.Request)) {
 	t.Helper()
-	httpmock.ActivateNonDefault(api.RClient.GetClient())
+	httpmock.Activate()
 	t.Cleanup(httpmock.Deactivate)
 	httpmock.ZeroCallCounters()
 	httpmock.RegisterResponder("GET", "https://api.soluble.cloud/api/v1/users/profile",
@@ -43,6 +43,7 @@ func TestAuthWithEnv(t *testing.T) {
 	// no need to run configure
 	opts := &options.ClientOpts{}
 	api, err := opts.GetAPIClient()
+	httpmock.ActivateNonDefault(api.GetClient().GetClient())
 	if !assert.NoError(err) {
 		return
 	}
@@ -78,6 +79,9 @@ func TestConfigure(t *testing.T) {
 	assert.NotNil(config.GetDefaultLaceworkProfile())
 	configCommand := &configureCommand{}
 	configCommand.Organization = "123456789012"
+	configCommand.clientHook = func(c *api.Client) {
+		httpmock.ActivateNonDefault(c.GetClient().GetClient())
+	}
 	n, err := configCommand.Run()
 	assert.NoError(err)
 	assert.NotNil(n)

--- a/pkg/api/credentials/credentials.go
+++ b/pkg/api/credentials/credentials.go
@@ -116,7 +116,7 @@ func (p *ProfileCredentials) RefreshToken(domain string, keyID string, secretKey
 	req.Header.Set("User-Agent", api.UserAgent)
 	req.Header.Set("X-LW-UAKS", secretKey)
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := api.RClient.GetClient().Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/credentials/credentials_test.go
+++ b/pkg/api/credentials/credentials_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/soluble-ai/soluble-cli/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +51,7 @@ func TestLoadCredentials(t *testing.T) {
 
 func TestRefresh(t *testing.T) {
 	assert := assert.New(t)
-	httpmock.ActivateNonDefault(api.RClient.GetClient())
+	httpmock.Activate()
 	t.Cleanup(httpmock.Deactivate)
 	dir, err := os.MkdirTemp("", "cli*")
 	if !assert.NoError(err) {

--- a/pkg/api/retry_test.go
+++ b/pkg/api/retry_test.go
@@ -16,7 +16,7 @@ func TestRetry(t *testing.T) {
 		RetryWaitSeconds: 0.1,
 	})
 	c.Organization = "1234"
-	httpmock.ActivateNonDefault(RClient.GetClient())
+	httpmock.ActivateNonDefault(c.GetClient().GetClient())
 	httpmock.ZeroCallCounters()
 	t.Cleanup(httpmock.Deactivate)
 	count := 2

--- a/pkg/tools/checkov/checkov.go
+++ b/pkg/tools/checkov/checkov.go
@@ -109,7 +109,7 @@ func (t *Tool) CommandTemplate() *cobra.Command {
 func (t *Tool) Run() (*tools.Result, error) {
 	dt := &tools.DockerTool{
 		Name:                "checkov",
-		Image:               "gcr.io/soluble-repo:2",
+		Image:               "gcr.io/soluble-repo/checkov:2",
 		DefaultNoDockerName: "checkov",
 		Args: []string{
 			"-o", "json", "-s", "--skip-download",


### PR DESCRIPTION
* Add api.Download method, to download stuff

* Remove misguided api.RClient test workaround

* Fix default checkov version

* Return an error if the query for tool version fails

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>