### PR TITLE
RAIN-38876: convert opal built in policies

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -3,6 +3,8 @@ package policy
 import (
 	"os"
 
+	"github.com/soluble-ai/soluble-cli/pkg/policy/policyimporter"
+
 	"github.com/soluble-ai/soluble-cli/pkg/api"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/policy/custompolicybuilder"
@@ -27,6 +29,7 @@ func Command() *cobra.Command {
 		uploadCommand(),
 		testCommand(),
 		CreateCommand(),
+		OpalConvertCommand(),
 	)
 	return c
 }
@@ -42,6 +45,25 @@ func CreateCommand() *cobra.Command {
 				return err
 			}
 			if err := cpb.CreateCustomPolicyTemplate(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return c
+}
+
+func OpalConvertCommand() *cobra.Command {
+	// only available for opal
+	c := &cobra.Command{
+		Use:   "convert",
+		Short: "Convert opal built-in policies",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			converter := &policyimporter.Converter{}
+			if err := converter.PromptInput(); err != nil {
+				return err
+			}
+			if err := converter.ConvertOpalBuiltIns(); err != nil {
 				return err
 			}
 			return nil

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -57,7 +57,7 @@ func OpalConvertCommand() *cobra.Command {
 	// only available for opal
 	c := &cobra.Command{
 		Use:   "convert",
-		Short: "Convert opal built-in policies",
+		Short: "Restructure and generate metadata for opal built-in policies to fit lacework directory structure.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			converter := &policyimporter.Converter{}
 			if err := converter.PromptInput(); err != nil {

--- a/pkg/policy/custompolicybuilder/test/custom_policy_test.go
+++ b/pkg/policy/custompolicybuilder/test/custom_policy_test.go
@@ -1,14 +1,12 @@
 package test
 
 import (
-	"bytes"
-	"log"
 	"os"
 	"testing"
 
-	"github.com/soluble-ai/soluble-cli/pkg/policy/custompolicybuilder"
+	"github.com/soluble-ai/soluble-cli/pkg/policy/testutil"
 
-	"gopkg.in/yaml.v3"
+	"github.com/soluble-ai/soluble-cli/pkg/policy/custompolicybuilder"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -21,20 +19,6 @@ func setupDirPath(path string) error {
 // Clean up after test
 func cleanUpPoliciesDir() {
 	os.RemoveAll("policies")
-}
-
-func readMetadataFile(path string) map[interface{}]interface{} {
-	f, err := os.ReadFile(path)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	data := make(map[interface{}]interface{})
-
-	if err := yaml.Unmarshal(f, &data); err != nil {
-		log.Fatal(err)
-	}
-	return data
 }
 
 func TestCreate_ExpectedMetadataYaml(t *testing.T) {
@@ -61,12 +45,7 @@ func TestCreate_ExpectedMetadataYaml(t *testing.T) {
 	// Compare Metadata.yaml
 	actualFilePath := "policies/opal/unit_test_cust_policy/metadata.yaml"
 	expectedFilePath := "testdata/policies/opal/unit_test_cust_policy/metadata.yaml"
-	actual := readMetadataFile(actualFilePath)
-	expected := readMetadataFile(expectedFilePath)
 
-	actData, _ := yaml.Marshal(actual)
-	expData, _ := yaml.Marshal(expected)
-
-	diff := bytes.Compare(actData, expData)
+	diff := testutil.CompareYamlFiles(actualFilePath, expectedFilePath)
 	assert.Equal(0, diff)
 }

--- a/pkg/policy/policyimporter/policy_import.go
+++ b/pkg/policy/policyimporter/policy_import.go
@@ -155,7 +155,7 @@ func (p *Policy) copyRegoFile(regoPath string) error {
 
 func (p *Policy) getID() string {
 	idName := strings.ReplaceAll(p.Name, "_", "-")
-	return "c-opl-" + idName
+	return "lacework-opl-" + idName
 }
 func doubleQuote(val string) yaml.Node {
 	node := yaml.Node{

--- a/pkg/policy/policyimporter/policy_import.go
+++ b/pkg/policy/policyimporter/policy_import.go
@@ -1,0 +1,354 @@
+package policyimporter
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Converter struct {
+	OpalRegoPath string
+	DestPath     string
+}
+
+type Policy struct {
+	Name      string
+	CheckType string
+	Tool      string
+	Dir       string
+	Desc      string
+	Title     string
+	Severity  string
+	RsrcType  string
+	Provider  string
+}
+
+type Metadata struct {
+	Category    string                 `yaml:"category"`
+	CheckTool   string                 `yaml:"checkTool"`
+	CheckType   []string               `yaml:"checkType"`
+	Description yaml.Node              `yaml:"description"`
+	Provider    string                 `yaml:"provider"`
+	Severity    string                 `yaml:"severity"`
+	Title       yaml.Node              `yaml:"title"`
+	ID          yaml.Node              `yaml:"id"`
+	LwIds       map[string]interface{} `yaml:"lwids"`
+}
+
+type Custom struct {
+	Controls map[string]interface{}
+	Severity string
+}
+type Metadoc struct {
+	Custom      Custom
+	Description string
+	Title       string
+	ID          string
+}
+
+var ManualCheck []string
+
+func (c *Converter) PromptInput() error {
+	var qs = []*survey.Question{
+		{
+			Name: "opalRegoPath",
+			Prompt: &survey.Input{
+				Message: "Opal policies directory path",
+			},
+			//Validate: validatePolicyDirectory(),
+		},
+		{
+			Name: "destPath",
+			Prompt: &survey.Input{
+				Message: "Converted policies destination path",
+				Default: "policies"},
+			//Validate: validatePolicyDirectory(),
+		},
+	}
+	if err := survey.Ask(qs, c); err == nil {
+		return err
+	}
+	return nil
+}
+
+func find(root, ext string) []string {
+	var regoFilePaths []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(d.Name()) == ext {
+			regoFilePaths = append(regoFilePaths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+	return regoFilePaths
+}
+func getName(fileName, rsrcType string) string {
+	if rsrcType != "" {
+		return rsrcType + "_" + fileName[:len(fileName)-5] // 5 = len(".rego")
+	} else {
+		return fileName[:len(fileName)-5]
+	}
+}
+
+func setupBaseDirStructure(path string) error {
+	// path = <...>/policies/opal/
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Policy) createPolicyDirStructure(destPath string) error {
+	p.Dir = destPath + "/" + p.Name + "/" + p.CheckType
+	// Ensure policy dir doesn't already exist
+	if _, err := os.Stat(p.Dir); !os.IsNotExist(err) {
+		return fmt.Errorf("policy '%v' with check type '%v' already exists: %v", p.Name, p.CheckType, p.Dir)
+	}
+	if err := os.MkdirAll(p.Dir, os.ModePerm); err != nil {
+		return err
+	} else {
+		fmt.Println("created: ", p.Dir)
+	}
+	return nil
+}
+func (p *Policy) copyRegoFile(regoPath string) error {
+	destination := p.Dir + "/policy.rego"
+	input, err := os.ReadFile(regoPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(destination, input, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Policy) getID() string {
+	idName := strings.ReplaceAll(p.Name, "_", "-")
+	return "c-opl-" + idName
+}
+func doubleQuote(val string) yaml.Node {
+	node := yaml.Node{
+		Value: val,
+		Kind:  yaml.ScalarNode,
+		Style: yaml.DoubleQuotedStyle,
+	}
+	return node
+}
+
+func (md *Metadoc) getMetadoc(regoPath string) error {
+	readFile, err := os.Open(regoPath)
+	if err != nil {
+		return err
+	}
+	fileScanner := bufio.NewScanner(readFile)
+	fileScanner.Split(bufio.ScanLines)
+
+	metadoc := "__rego__metadoc__ := {"
+	open := 0
+	closed := 0
+
+	for fileScanner.Scan() {
+		line := fileScanner.Text()
+		if open > 0 {
+			metadoc += line
+		}
+		if strings.Contains(line, metadoc) || strings.ContainsAny(line, "{}") {
+			open += strings.Count(line, "{")
+			closed += strings.Count(line, "}")
+			if closed == open {
+				break
+			}
+		}
+	}
+	if err = readFile.Close(); err != nil {
+		return err
+	}
+
+	metaJSON := strings.Split(metadoc, "__rego__metadoc__ :=")[1]
+	if err = json.Unmarshal([]byte(metaJSON), &md); err != nil {
+		return err
+	}
+	return nil
+}
+
+func mergeMaps(maps ...map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func updateMetadata(name string, existing, new Metadata) Metadata {
+	// if metadata has conflicting values - add to manual check list
+	// else update check type and return NEW metadata
+	// merge LWIDs as many policies with same ID dont have all the lwids
+
+	new.CheckType = append(new.CheckType, existing.CheckType...)
+	if existing.Category != new.Category ||
+		existing.Description.Value != new.Description.Value ||
+		existing.Severity != new.Severity ||
+		existing.Title.Value != new.Title.Value {
+		ManualCheck = append(ManualCheck, name)
+	} else if !reflect.DeepEqual(existing.LwIds, new.LwIds) {
+		new.LwIds = mergeMaps(existing.LwIds, new.LwIds)
+	}
+	return new
+}
+
+func (p *Policy) generateMetadataYaml(regoPath string) error {
+	// don't blindly overwrite an existing metadata.yaml file
+	existingMd := Metadata{}
+	metadataPath := strings.Split(p.Dir, p.CheckType)[0] + "metadata.yaml"
+	if _, err := os.Stat(metadataPath); !os.IsNotExist(err) {
+		md, err := os.ReadFile(metadataPath)
+		if err != nil {
+			return err
+		}
+
+		if err = yaml.Unmarshal(md, &existingMd); err != nil {
+			return err
+		}
+	}
+
+	metadoc := Metadoc{}
+	if err := metadoc.getMetadoc(regoPath); err != nil {
+		return err
+	}
+
+	metadata := Metadata{
+		Category:    p.RsrcType,
+		CheckTool:   p.Tool,
+		CheckType:   []string{p.CheckType},
+		Description: doubleQuote(metadoc.Description),
+		Provider:    p.Provider,
+		Severity:    metadoc.Custom.Severity,
+		Title:       doubleQuote(metadoc.Title),
+		LwIds:       metadoc.Custom.Controls,
+		ID:          doubleQuote(p.getID()),
+	}
+
+	// CheckTool isn't set for an empty Metadata struct
+	if existingMd.CheckTool == "opal" {
+		metadata = updateMetadata(p.Name, existingMd, metadata)
+	}
+
+	data, err := yaml.Marshal(&metadata)
+	if err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(metadataPath, data, 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Policy) convertPolicy(regoPath, destPath string) error {
+	if err := p.createPolicyDirStructure(destPath); err != nil {
+		return err
+	}
+
+	err := p.generateMetadataYaml(regoPath)
+	if err != nil {
+		return err
+	}
+
+	if err = p.copyRegoFile(regoPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Policy) convert(regoFile, destPath string) error {
+	relPath := strings.Split(regoFile, "/policies/")[1]
+	pathData := strings.Split(relPath, "/")
+	checkTypeMap := map[string]string{
+		"tf":  "terraform",
+		"k8s": "kubernetes",
+		"cfn": "cloudformation",
+		"arm": "arm",
+	}
+	providerMap := map[string]string{
+		"aws":     "aws",
+		"google":  "gcp",
+		"azurerm": "azure",
+	}
+
+	checkType := pathData[0]
+	p.CheckType = checkTypeMap[checkType]
+
+	switch {
+	case checkType == "tf":
+		// tf/<provider>/<rsrcType>/<name>.rego
+		p.Provider = providerMap[pathData[1]]
+		p.RsrcType = pathData[2]
+		p.Name = getName(pathData[3], p.RsrcType)
+
+	case checkType == "k8s":
+		// k8s/<name>.rego
+		p.RsrcType = checkType
+		p.Name = getName(pathData[1], p.RsrcType)
+
+	case checkType == "cfn", checkType == "arm":
+		// cfn/<rsrcType>/<name>.rego
+		// arm/<rsrcType>/<name>.rego
+		p.RsrcType = pathData[1]
+		p.Name = getName(pathData[2], p.RsrcType)
+	}
+	if err := p.convertPolicy(regoFile, destPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Converter) ConvertOpalBuiltIns() error {
+	// lw path = policies/opal/<policy_name>/<checkType>
+	expectedPath := "policies/opal"
+	sub := len(c.DestPath) - len(expectedPath)
+	if len(c.DestPath) < len(expectedPath) || c.DestPath[sub:] != expectedPath {
+		return fmt.Errorf("invalid directory path: %v", c.DestPath+
+			"\nprovide path to 'policies/opal' directory")
+	}
+	if err := setupBaseDirStructure(c.DestPath); err != nil {
+		log.Fatalln(err)
+	}
+
+	regoFiles := find(c.OpalRegoPath, ".rego")
+
+	for i := len(regoFiles) - 1; i != 0; i-- {
+		fmt.Println("rego path: ", regoFiles[i])
+		p := Policy{Tool: "opal"}
+		if err := p.convert(regoFiles[i], c.DestPath); err != nil {
+			return (err)
+		}
+	}
+
+	if ManualCheck != nil {
+		fmt.Printf(" Conversion not complete for the following %v policies: ", len(ManualCheck))
+		fmt.Printf("Manually validate conversion of __rego__metadoc__'s for: \n %v ", ManualCheck)
+	} else {
+		fmt.Println("All policies converted with no issues")
+	}
+	return nil
+}

--- a/pkg/policy/policyimporter/policy_import.go
+++ b/pkg/policy/policyimporter/policy_import.go
@@ -81,7 +81,7 @@ func (c *Converter) PromptInput() error {
 	return nil
 }
 
-func find(root, ext string) []string {
+func Find(root, ext string) []string {
 	var regoFilePaths []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -280,7 +280,7 @@ func (p *Policy) convertPolicy(regoPath, destPath string) error {
 	return nil
 }
 
-func (p *Policy) convert(regoFile, destPath string) error {
+func (p *Policy) Convert(regoFile, destPath string) error {
 	relPath := strings.Split(regoFile, "/policies/")[1]
 	pathData := strings.Split(relPath, "/")
 	checkTypeMap := map[string]string{
@@ -334,12 +334,12 @@ func (c *Converter) ConvertOpalBuiltIns() error {
 		log.Fatalln(err)
 	}
 
-	regoFiles := find(c.OpalRegoPath, ".rego")
+	regoFiles := Find(c.OpalRegoPath, ".rego")
 
-	for i := len(regoFiles) - 1; i != 0; i-- {
+	for i := len(regoFiles) - 1; i >= 0; i-- {
 		fmt.Println("rego path: ", regoFiles[i])
 		p := Policy{Tool: "opal"}
-		if err := p.convert(regoFiles[i], c.DestPath); err != nil {
+		if err := p.Convert(regoFiles[i], c.DestPath); err != nil {
 			return (err)
 		}
 	}

--- a/pkg/policy/policyimporter/policy_import.go
+++ b/pkg/policy/policyimporter/policy_import.go
@@ -83,7 +83,6 @@ func (c *Converter) PromptInput() error {
 			Prompt: &survey.Input{
 				Message: "Converted policies destination path",
 				Help:    "must point to a 'policies/opal' directory",
-
 			},
 			Validate: validatePath("policies/opal"),
 		},
@@ -146,7 +145,7 @@ func (p *Policy) copyRegoFile(regoPath string) error {
 		return err
 	}
 
-	err = os.WriteFile(destination, input, 0644)
+	err = os.WriteFile(destination, input, 0600)
 	if err != nil {
 		return err
 	}
@@ -271,7 +270,7 @@ func (p *Policy) generateMetadataYaml(regoPath string) error {
 		return err
 	}
 
-	if err = os.WriteFile(metadataPath, data, 0644); err != nil {
+	if err = os.WriteFile(metadataPath, data, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/policy/policyimporter/policy_import.go
+++ b/pkg/policy/policyimporter/policy_import.go
@@ -82,7 +82,9 @@ func (c *Converter) PromptInput() error {
 			Name: "destPath",
 			Prompt: &survey.Input{
 				Message: "Converted policies destination path",
-				Default: "policies"},
+				Help:    "must point to a 'policies/opal' directory",
+
+			},
 			Validate: validatePath("policies/opal"),
 		},
 	}

--- a/pkg/policy/policyimporter/test/policy_import_test.go
+++ b/pkg/policy/policyimporter/test/policy_import_test.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/soluble-ai/soluble-cli/pkg/policy/policyimporter"
+	"github.com/soluble-ai/soluble-cli/pkg/policy/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func cleanUp() {
+	os.RemoveAll("testdata/tmp")
+}
+func Test_converter(t *testing.T) {
+	assert := assert.New(t)
+	defer cleanUp()
+
+	input := "testdata/input/policies"
+	dest := "testdata/tmp/policies/opal"
+	regoFiles := policyimporter.Find(input, ".rego")
+
+	for i := len(regoFiles) - 1; i >= 0; i-- {
+		fmt.Println("rego path: ", regoFiles[i])
+		p := policyimporter.Policy{Tool: "opal"}
+		if err := p.Convert(regoFiles[i], dest); err != nil {
+			t.Fail()
+		}
+	}
+
+	// test structure
+	lwStructure := policyimporter.Find(dest, ".rego")
+	assert.Equal(lwStructure[0], "testdata/tmp/policies/opal/s3_https_access/cloudformation/policy.rego")
+	assert.Equal(lwStructure[1], "testdata/tmp/policies/opal/s3_https_access/terraform/policy.rego")
+
+	// test metadata
+	expectedFilePath := "testdata/expected/metadata.yaml"
+	actualFilePath := "testdata/tmp/policies/opal/s3_https_access/metadata.yaml"
+	diff := testutil.CompareYamlFiles(actualFilePath, expectedFilePath)
+	assert.Equal(0, diff)
+}

--- a/pkg/policy/policyimporter/test/testdata/expected/metadata.yaml
+++ b/pkg/policy/policyimporter/test/testdata/expected/metadata.yaml
@@ -1,0 +1,15 @@
+category: s3
+checkTool: opal
+checkType:
+    - cloudformation
+    - terraform
+description: "S3 bucket policies should only allow requests that use HTTPS. To protect data in transit, an S3 bucket policy should deny all HTTP requests to its objects and allow only HTTPS requests. HTTPS uses Transport Layer Security (TLS) to encrypt data, which preserves integrity and prevents tampering."
+provider: ""
+severity: Medium
+title: "S3 bucket policies should only allow requests that use HTTPS"
+id: "c-opl-s3-https-access"
+lwids:
+    CIS-AWS_v1.3.0:
+        - CIS-AWS_v1.3.0_2.1.2
+    CIS-AWS_v1.4.0:
+        - CIS-AWS_v1.4.0_2.1.2

--- a/pkg/policy/policyimporter/test/testdata/expected/metadata.yaml
+++ b/pkg/policy/policyimporter/test/testdata/expected/metadata.yaml
@@ -7,7 +7,7 @@ description: "S3 bucket policies should only allow requests that use HTTPS. To p
 provider: ""
 severity: Medium
 title: "S3 bucket policies should only allow requests that use HTTPS"
-id: "c-opl-s3-https-access"
+id: "lacework-opl-s3-https-access"
 lwids:
     CIS-AWS_v1.3.0:
         - CIS-AWS_v1.3.0_2.1.2

--- a/pkg/policy/policyimporter/test/testdata/input/policies/cfn/s3/https_access.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policies/cfn/s3/https_access.rego
@@ -1,0 +1,77 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package policies.cfn_s3_https_access
+
+import data.lacework
+import data.cfn.s3
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_2.1.2"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.1.2"
+      ]
+    },
+    "severity": "Medium"
+  },
+  "description": "S3 bucket policies should only allow requests that use HTTPS. To protect data in transit, an S3 bucket policy should deny all HTTP requests to its objects and allow only HTTPS requests. HTTPS uses Transport Layer Security (TLS) to encrypt data, which preserves integrity and prevents tampering.",
+  "id": "FG_R00100",
+  "title": "S3 bucket policies should only allow requests that use HTTPS"
+}
+
+input_type := "cfn"
+resource_type := "MULTIPLE"
+
+buckets := lacework.resources("AWS::S3::Bucket")
+bucket_policies := lacework.resources("AWS::S3::BucketPolicy")
+
+policies_for_bucket(bucket) = ret {
+  ret := [p | 
+    p := bucket_policies[_]
+    s3.matches_bucket_name_or_id(bucket, p.Bucket)
+  ]
+}
+
+specifies_secure_transport(statement) {
+  secure_transport_values := as_array(statement.Condition.Bool["aws:SecureTransport"])
+  secure_transport_values[_] == false
+  statement.Effect == "Deny"
+
+  actions := as_array(statement.Action)
+  related_actions := {"s3:GetObject", "s3:*", "*"}
+  related_actions[actions[_]]
+}
+
+valid_buckets[bucket_id] = bucket {
+  bucket := buckets[bucket_id]
+  policies := policies_for_bucket(bucket)
+  pol := policies[_]
+  statements := as_array(pol.PolicyDocument.Statement)
+  specifies_secure_transport(statements[_])
+}
+
+policy[j] {
+  b := valid_buckets[_]
+  j := lacework.allow_resource(b)
+} {
+  b := buckets[id]
+  not valid_buckets[id]
+  j := lacework.deny_resource(b)
+}
+
+# Utility: turns anything into an array, if it's not an array already.
+as_array(x) = [x] {not is_array(x)} else = x {true}

--- a/pkg/policy/policyimporter/test/testdata/input/policies/tf/aws/s3/https_access.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policies/tf/aws/s3/https_access.rego
@@ -1,0 +1,79 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package policies.tf_aws_s3_https_access
+
+import data.lacework
+import data.aws.s3.s3_library as lib
+import data.aws.iam.policy_document_library as doclib
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_2.1.2"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.1.2"
+      ]
+    },
+    "severity": "Medium"
+  },
+  "description": "S3 bucket policies should only allow requests that use HTTPS. To protect data in transit, an S3 bucket policy should deny all HTTP requests to its objects and allow only HTTPS requests. HTTPS uses Transport Layer Security (TLS) to encrypt data, which preserves integrity and prevents tampering.",
+  "id": "FG_R00100",
+  "title": "S3 bucket policies should only allow requests that use HTTPS"
+}
+
+# This checks if this statement denies HTTPS requests.  In order for a statement
+# to match:
+#
+# - `Effect` needs to be set to `Deny`
+# - `Condition` needs to be set to `aws:SecureTransport == false`
+# - `Action` needs to set to `s3:GetObject` or `s3:*`, or `*`
+specifies_secure_transport(statement) {
+  secure_transport_values = as_array(statement.Condition.Bool["aws:SecureTransport"])
+  secure_transport_values == ["false"]
+  statement.Effect == "Deny"
+
+  actions = as_array(statement.Action)
+  related_actions = {"s3:GetObject", "s3:*", "*"}
+  related_actions[actions[_]]
+}
+
+buckets = lacework.resources("aws_s3_bucket")
+
+# A valid policy specifies a `specifies_secure_transport` statement for the
+# "s3:GetObject" method.  See also:
+# <https://aws.amazon.com/blogs/security/how-to-use-bucket-policies-and-apply-defense-in-depth-to-help-secure-your-amazon-s3-data/>
+valid_buckets[bucket_id] = bucket {
+  bucket = buckets[bucket_id]
+  policies = lib.bucket_policies_for_bucket(bucket)
+  pol = policies[_]
+  doc = doclib.to_policy_document(pol)
+  statements = as_array(doc.Statement)
+  specifies_secure_transport(statements[_])
+}
+
+resource_type := "MULTIPLE"
+
+policy[j] {
+  b = valid_buckets[_]
+  j = lacework.allow_resource(b)
+} {
+  b = buckets[id]
+  not valid_buckets[id]
+  j = lacework.deny_resource(b)
+}
+
+# Utility: turns anything into an array, if it's not an array already.
+as_array(x) = [x] {not is_array(x)} else = x {true}

--- a/pkg/policy/testutil/test_util.go
+++ b/pkg/policy/testutil/test_util.go
@@ -1,0 +1,34 @@
+package testutil
+
+import (
+	"bytes"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func readYamlFile(path string) map[interface{}]interface{} {
+	f, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	data := make(map[interface{}]interface{})
+
+	if err := yaml.Unmarshal(f, &data); err != nil {
+		log.Fatal(err)
+	}
+	return data
+}
+
+func CompareYamlFiles(file1, file2 string) int {
+	yaml1 := readYamlFile(file1)
+	yaml2 := readYamlFile(file2)
+
+	data1, _ := yaml.Marshal(yaml1)
+	data2, _ := yaml.Marshal(yaml2)
+
+	diff := bytes.Compare(data1, data2)
+	return diff
+}


### PR DESCRIPTION
### JIRA
> https://lacework.atlassian.net/browse/RAIN-38876

command: `early-access policy convert `

Converter will ask for user input:
> target directory for converted policies ( must point to a `policies/opal` dir)
> path to policies to be converted (example `opal/rego/policies`

Result: 
Converter will create a lacework directory structure for the policies.
The ` __rego__metadoc__` in the rego file is extracted and converted to a metadata.yaml file.
metadata.yaml file will also be populate with other relevant data.
rego file will be renamed as policy.rego

Expect 11 policies to require a manual intervention where rego__metadoc values (E.G. description field) differed.
There will be listed after running the converter

example metadata.yaml:
```
category: s3
checkTool: opal
checkType:
    - cloudformation
    - terraform
description: "S3 bucket policies should only allow requests that use HTTPS. To protect data in transit, an S3 bucket policy should deny all HTTP requests to its objects and allow only HTTPS requests. HTTPS uses Transport Layer Security (TLS) to encrypt data, which preserves integrity and prevents tampering."
provider: ""
severity: Medium
title: "S3 bucket policies should only allow requests that use HTTPS"
id: "c-opl-s3-https-access"
lwids:
    CIS-AWS_v1.3.0:
        - CIS-AWS_v1.3.0_2.1.2
    CIS-AWS_v1.4.0:
        - CIS-AWS_v1.4.0_2.1.2

```
### Test
test added
