### PR TITLE
fix(RAIN-38777) ensure all policyId's are lower case

### DIFF
--- a/pkg/policy/manager/detect.go
+++ b/pkg/policy/manager/detect.go
@@ -52,6 +52,7 @@ func (m *M) DetectPolicy(dir string) error {
 				var policyType policies.PolicyType
 				m.Dir = strings.Join(elements[0:i], string(os.PathSeparator))
 				m.Policies = make(map[policies.PolicyType][]*policies.Policy)
+				m.PolicyIds = make(map[string]string)
 				// look at the path elements past "policies" to see where
 				// we are
 				n := len(elements) - i

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -1,0 +1,47 @@
+package policy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockPolicyType struct{}
+
+func (mockPolicyType) GetName() string {
+	return "mockPolicyType"
+}
+func (mockPolicyType) GetCode() string {
+	return "mock"
+}
+
+func (t mockPolicyType) PreparePolicies(policies []*Policy, dest string) error {
+	return nil
+}
+
+func TestResolvePolicyIDOkay(t *testing.T) {
+	assertPolicyIDOkay(t, newStore(), "a_test_policy", "c-mock-a-test-policy")
+}
+
+func TestResolvePolicyIDExists(t *testing.T) {
+	store := newStore()
+	path := "a_test_policy"
+	assertPolicyIDOkay(t, store, path, "c-mock-a-test-policy")
+	policyID, err := store.resolvePolicyID(mockPolicyType{}, path)
+	assert.Equal(t, "", policyID)
+	assert.Error(t, err)
+	assert.Equal(t, errors.New("a policy with id: c-mock-a-test-policy already exists"), err)
+}
+
+func assertPolicyIDOkay(t *testing.T, store *Store, path string, expected string) {
+	policyID, err := store.resolvePolicyID(mockPolicyType{}, path)
+	assert.Equal(t, expected, policyID)
+	assert.Nil(t, err)
+}
+
+func newStore() *Store {
+	return &Store{
+		PolicyIds: make(map[string]string),
+	}
+}

--- a/pkg/tools/assessmentopts.go
+++ b/pkg/tools/assessmentopts.go
@@ -142,7 +142,11 @@ func (o *AssessmentOpts) GetCustomPoliciesDir(policyTypeName string, morePolicyT
 		o.customPoliciesDir = &zero
 		log.Infof("{primary:%s} has no custom policies", o.Tool.Name())
 	} else {
-		store := &policy.Store{Dir: dir, Policies: make(map[policy.PolicyType][]*policy.Policy)}
+		store := &policy.Store{
+			Dir:       dir,
+			Policies:  make(map[policy.PolicyType][]*policy.Policy),
+			PolicyIds: make(map[string]string),
+		}
 		dest, err := os.MkdirTemp("", "policy*")
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Signed-off-by: Martin Scott <martin.scott@lacework.net>

https://lacework.atlassian.net/browse/RAIN-38777

Ensure all policyId's are generated in lowercase.

For Case sensitive file systems, we check if the policyId already exists and throw an error if this is the case. The user can then take action to rename any clashes e.g. MY_POLICY, my_policy.