### PR TITLE
RAIN-39247:  populate iac-content repo with embedded opal policies

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -59,7 +59,7 @@ var InputTypeForTarget = map[Target]string{
 }
 
 var allTargets = []Target{
-	Terraform, TerraformPlan, Cloudformation, Kubernetes, Helm, Docker, Secrets,
+	Terraform, TerraformPlan, Cloudformation, Kubernetes, Helm, Docker, Secrets, ARM,
 }
 
 type PolicyType interface {

--- a/pkg/policy/policyimporter/policy_import.go
+++ b/pkg/policy/policyimporter/policy_import.go
@@ -217,13 +217,14 @@ func updateMetadata(name string, existing, new Metadata) Metadata {
 	// merge LWIDs as many policies with same ID dont have all the lwids
 
 	new.CheckType = append(new.CheckType, existing.CheckType...)
+	if !reflect.DeepEqual(existing.LwIds, new.LwIds) {
+		new.LwIds = mergeMaps(existing.LwIds, new.LwIds)
+	}
 	if existing.Category != new.Category ||
 		existing.Description.Value != new.Description.Value ||
 		existing.Severity != new.Severity ||
 		existing.Title.Value != new.Title.Value {
 		ManualCheck = append(ManualCheck, name)
-	} else if !reflect.DeepEqual(existing.LwIds, new.LwIds) {
-		new.LwIds = mergeMaps(existing.LwIds, new.LwIds)
 	}
 	return new
 }

--- a/pkg/policy/policyimporter/policy_import.go
+++ b/pkg/policy/policyimporter/policy_import.go
@@ -18,6 +18,7 @@ import (
 type Converter struct {
 	OpalRegoPath string
 	DestPath     string
+	TestPath     string
 }
 
 type Policy struct {
@@ -55,6 +56,19 @@ type Metadoc struct {
 	ID          string
 }
 
+var checkTypeMap = map[string]string{
+"tf":  "terraform",
+"k8s": "kubernetes",
+"cfn": "cloudformation",
+"arm": "arm",
+}
+
+var providerMap = map[string]string{
+"aws":     "aws",
+"google":  "gcp",
+"azurerm": "azure",
+}
+
 var ManualCheck []string
 
 func validatePath(expectedPath string) func(interface{}) error {
@@ -79,6 +93,12 @@ func (c *Converter) PromptInput() error {
 			Validate: validatePath("policies"),
 		},
 		{
+			Name: "testPath",
+			Prompt: &survey.Input{
+				Message: "Opal tests/policies directory path (optional)",
+			},
+		},
+		{
 			Name: "destPath",
 			Prompt: &survey.Input{
 				Message: "Converted policies destination path",
@@ -99,6 +119,9 @@ func Find(root, ext string) []string {
 		if err != nil {
 			return err
 		}
+		if d.IsDir() && d.Name() == "inputs" {
+			return fs.SkipDir
+		}
 		if filepath.Ext(d.Name()) == ext {
 			regoFilePaths = append(regoFilePaths, path)
 		}
@@ -111,9 +134,20 @@ func Find(root, ext string) []string {
 }
 func getName(fileName, rsrcType string) string {
 	if rsrcType != "" {
-		return rsrcType + "_" + fileName[:len(fileName)-5] // 5 = len(".rego")
+		return rsrcType + "_" + strings.Split(fileName, ".")[0] // 5 = len(".rego")
 	} else {
 		return fileName[:len(fileName)-5]
+	}
+}
+
+func (p *Policy)setTestName(testPath, testName string) {
+	var relPath string
+	if p.CheckType != "kubernetes"{
+		relPath = strings.Split(testPath, p.RsrcType + "/")[1]
+		p.Name = p.RsrcType + "_" + strings.Split(relPath, "_test.rego")[0]
+
+	} else {
+		p.Name = p.RsrcType + "_" + testName
 	}
 }
 
@@ -133,14 +167,25 @@ func (p *Policy) createPolicyDirStructure(destPath string) error {
 	}
 	if err := os.MkdirAll(p.Dir, os.ModePerm); err != nil {
 		return err
-	} else {
-		fmt.Println("created: ", p.Dir)
 	}
 	return nil
 }
-func (p *Policy) copyRegoFile(regoPath string) error {
-	destination := p.Dir + "/policy.rego"
-	input, err := os.ReadFile(regoPath)
+
+func (p *Policy) createTestDirStructure() error {
+	if _, err := os.Stat(p.Dir); !os.IsNotExist(err) {
+		if err = os.MkdirAll(p.Dir + "/tests/inputs", os.ModePerm); err != nil {
+			return err
+		} else {
+			fmt.Println("created: ", p.Dir + "/tests/inputs")
+		}
+	} else {
+		return fmt.Errorf("%v : policy '%v' with check type %v does not exist", p.Dir, p.Name, p.CheckType)
+	}
+	return nil
+}
+
+func copyFile(path, destination string) error {
+	input, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -287,27 +332,16 @@ func (p *Policy) convertPolicy(regoPath, destPath string) error {
 		return err
 	}
 
-	if err = p.copyRegoFile(regoPath); err != nil {
+	destination := p.Dir + "/policy.rego"
+	if err = copyFile(regoPath, destination); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (p *Policy) Convert(regoFile, destPath string) error {
+func (p *Policy) getPolicyData(regoFile string) {
 	relPath := strings.Split(regoFile, "/policies/")[1]
 	pathData := strings.Split(relPath, "/")
-	checkTypeMap := map[string]string{
-		"tf":  "terraform",
-		"k8s": "kubernetes",
-		"cfn": "cloudformation",
-		"arm": "arm",
-	}
-	providerMap := map[string]string{
-		"aws":     "aws",
-		"google":  "gcp",
-		"azurerm": "azure",
-	}
-
 	checkType := pathData[0]
 	p.CheckType = checkTypeMap[checkType]
 
@@ -329,10 +363,163 @@ func (p *Policy) Convert(regoFile, destPath string) error {
 		p.RsrcType = pathData[1]
 		p.Name = getName(pathData[2], p.RsrcType)
 	}
-	if err := p.convertPolicy(regoFile, destPath); err != nil {
-		return err
+}
+
+
+func (p *Policy)convertAllInputDir(inputFiles []fs.DirEntry, opalInputPath string) error {
+	for _, f := range inputFiles{
+		if err := copyFile(filepath.Join(opalInputPath, f.Name()), filepath.Join(p.Dir, "tests/inputs", f.Name())); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+
+
+func (p *Policy)getOpalInputPath(testPath, dirName string) string {
+	var opalInputPath string
+	if p.CheckType == "kubernetes"{
+		opalInputPath = filepath.Join(strings.SplitAfter(testPath, dirName)[0], "inputs")
+
+	} else {
+		opalInputPath = filepath.Join(strings.SplitAfter(testPath, p.RsrcType)[0], "inputs")
+	}
+	return opalInputPath
+}
+
+func (p *Policy)convertTests(testPath, destPath string) error {
+	dirs, _ := os.ReadDir(testPath)
+	for _, d := range dirs {
+		if p.CheckType != "kubernetes"{
+			p.RsrcType = d.Name()
+		}
+		tests := Find(filepath.Join(testPath, d.Name()), ".rego")
+
+		for _, t := range tests {
+			p.setTestName(t, d.Name())
+			p.Dir = filepath.Join(destPath, p.Name, p.CheckType)
+			
+			if err := p.createTestDirStructure(); err != nil {
+				return err
+			}
+			if err := copyFile(t, filepath.Join(p.Dir, "tests/policy_test.rego")); err != nil {
+				return err
+			}
+			
+			opalInputPath := p.getOpalInputPath(t, d.Name())
+			inputFiles, err := os.ReadDir(opalInputPath)
+			if err != nil {
+				return err
+			}
+			
+			if len(tests) == 1 {
+				// only 1 test in the directory; all input files are needed
+				err := p.convertAllInputDir(inputFiles, opalInputPath)
+				if err != nil {
+					return err
+				}
+			} else {
+				//multiple tests in directory; not all input files are needed
+				err := p.convertMultiTestDir(inputFiles, opalInputPath, t)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+
+func (p *Policy) getTestsByCheckType(testDir, destPath string) error {
+	checkTypeAbbrv := strings.Split(testDir, "/policies/")[1]
+	p.CheckType = checkTypeMap[checkTypeAbbrv]
+	if checkTypeAbbrv == "k8s" {
+		p.RsrcType = checkTypeAbbrv
+		err := p.convertTests(testDir, destPath)
+		if err != nil {
+			return err
+		}
+	} else if checkTypeAbbrv == "tf" {
+		for provider ,_ := range providerMap {
+			testDir = filepath.Join(testDir, provider)
+			err := p.convertTests(testDir, destPath)
+			if err != nil {
+				return err
+			}
+		}
+	} else if checkTypeAbbrv == "cfn" || checkTypeAbbrv == "arm" {
+		err := p.convertTests(testDir, destPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Policy)convertMultiTestDir(inputFiles []fs.DirEntry, opalInputPath, testPath string) error {
+	// get input required by test
+	testInputs, err := getInputs(testPath)
+	if err != nil {
+		return err
+	}
+	for _, input := range testInputs {
+		input = normaliseFileName(input)
+		for _, f := range inputFiles {
+			//ensure we get all relevant inputs
+			file := normaliseFileName(f.Name())
+
+			if file == input  {
+				destination := filepath.Join(p.Dir, "tests/inputs", f.Name())
+				if err := copyFile(filepath.Join(opalInputPath, f.Name()), destination); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func normaliseFileName(file string) string {
+	//This is to ensure we get all relevant input files
+	//remove extension
+	fileExt := filepath.Ext(file)
+	file = file[:len(file)-len(fileExt)]
+	//remove ending with _json _yaml or _tf
+	lastIdx := strings.LastIndex(file, "_")
+	if lastIdx != -1 {
+		dataType := file[lastIdx:]
+		if dataType == "_json" || dataType == "_yaml" || dataType == "_tf" {
+			file = strings.Split(file, dataType)[0]
+		}
+	}
+	return file
+}
+
+func getInputs(testFile string) ([]string, error) {
+	readFile, err := os.Open(testFile)
+	if err != nil {
+		return nil, err
+	}
+	fileScanner := bufio.NewScanner(readFile)
+	fileScanner.Split(bufio.ScanLines)
+
+	var inputs []string
+	for fileScanner.Scan() {
+		line := fileScanner.Text()
+		if strings.Contains(line, "inputs.") {
+			input := strings.Split(line, "inputs.")[1]
+			input = strings.Split(input, " ")[0]
+			input = strings.Split(input, ".")[0]
+			inputs = append(inputs, input)
+		}
+	}
+	if err = readFile.Close(); err != nil {
+		return nil, err
+	}
+
+	return inputs, nil
 }
 
 func (c *Converter) ConvertOpalBuiltIns() error {
@@ -342,12 +529,21 @@ func (c *Converter) ConvertOpalBuiltIns() error {
 	}
 
 	regoFiles := Find(c.OpalRegoPath, ".rego")
-
 	for i := len(regoFiles) - 1; i >= 0; i-- {
 		fmt.Println("converting: ", regoFiles[i])
 		p := Policy{Tool: "opal"}
-		if err := p.Convert(regoFiles[i], c.DestPath); err != nil {
+		p.getPolicyData(regoFiles[i])
+		if err := p.convertPolicy(regoFiles[i], c.DestPath); err != nil {
 			return err
+		}
+	}
+
+	if c.TestPath != ""{
+		for t, _ := range checkTypeMap {
+			p := Policy{Tool: "opal"}
+			if err := p.getTestsByCheckType(filepath.Join(c.TestPath,t), c.DestPath); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/policy/policyimporter/test/policy_import_test.go
+++ b/pkg/policy/policyimporter/test/policy_import_test.go
@@ -21,7 +21,7 @@ func exists(file string) error {
 func Test_converter(t *testing.T) {
 	assert := assert.New(t)
 	cleanUp()
-	//defer cleanUp()
+	defer cleanUp()
 
 	converter := &policyimporter.Converter{
 		OpalRegoPath :  "testdata/input/policies",
@@ -41,18 +41,11 @@ func Test_converter(t *testing.T) {
 	// test dir structure
 	// test all policies were created
 	assert.NoError(exists("s3_block_public_access/cloudformation/policy.rego"))
-	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_read/cloudformation/policy.rego"))
-	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_write/cloudformation/policy.rego"))
 	assert.NoError(exists("s3_encryption/cloudformation/policy.rego"))
-	//assert.NoError(exists("s3_https_access/cloudformation/policy.rego"))
-	//assert.NoError(exists("s3_https_access/terraform/policy.rego"))
 
 	// check test policies exist
 	assert.NoError(exists("s3_block_public_access/cloudformation/tests/policy_test.rego"))
-	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_read/cloudformation/tests/policy_test.rego"))
-	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_write/cloudformation/tests/policy_test.rego"))
 	assert.NoError(exists("s3_encryption/cloudformation/tests/policy_test.rego"))
-	//assert.NoError(exists("s3_https_access/cloudformation/tests/policy_test.rego"))
 
 	// check relevant input files exist
 	assert.NoError(exists("s3_block_public_access/cloudformation/tests/inputs/invalid_block_public_access_infra.yaml"))

--- a/pkg/policy/policyimporter/test/policy_import_test.go
+++ b/pkg/policy/policyimporter/test/policy_import_test.go
@@ -1,42 +1,63 @@
 package test
 
 import (
-	"fmt"
-	"os"
-	"testing"
-
 	"github.com/soluble-ai/soluble-cli/pkg/policy/policyimporter"
 	"github.com/soluble-ai/soluble-cli/pkg/policy/testutil"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
 )
 
 func cleanUp() {
 	os.RemoveAll("testdata/tmp")
 }
+
+
+func exists(file string) error {
+	_, err := os.Stat("testdata/tmp/policies/opal/" + file)
+	return err
+}
+
 func Test_converter(t *testing.T) {
 	assert := assert.New(t)
-	defer cleanUp()
+	cleanUp()
+	//defer cleanUp()
 
-	input := "testdata/input/policies"
-	dest := "testdata/tmp/policies/opal"
-	regoFiles := policyimporter.Find(input, ".rego")
-
-	for i := len(regoFiles) - 1; i >= 0; i-- {
-		fmt.Println("rego path: ", regoFiles[i])
-		p := policyimporter.Policy{Tool: "opal"}
-		if err := p.Convert(regoFiles[i], dest); err != nil {
-			t.Fail()
-		}
+	converter := &policyimporter.Converter{
+		OpalRegoPath :  "testdata/input/policies",
+		DestPath: "testdata/tmp/policies/opal",
+		TestPath: "testdata/input/policiesTest/tests/policies",
+	}
+	if err := converter.ConvertOpalBuiltIns(); err != nil {
+		t.Fail()
 	}
 
-	// test structure
-	lwStructure := policyimporter.Find(dest, ".rego")
-	assert.Equal(lwStructure[0], "testdata/tmp/policies/opal/s3_https_access/cloudformation/policy.rego")
-	assert.Equal(lwStructure[1], "testdata/tmp/policies/opal/s3_https_access/terraform/policy.rego")
-
-	// test metadata
+	//test metadata
 	expectedFilePath := "testdata/expected/metadata.yaml"
 	actualFilePath := "testdata/tmp/policies/opal/s3_https_access/metadata.yaml"
 	diff := testutil.CompareYamlFiles(actualFilePath, expectedFilePath)
 	assert.Equal(0, diff)
+
+	// test dir structure
+	// test all policies were created
+	assert.NoError(exists("s3_block_public_access/cloudformation/policy.rego"))
+	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_read/cloudformation/policy.rego"))
+	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_write/cloudformation/policy.rego"))
+	assert.NoError(exists("s3_encryption/cloudformation/policy.rego"))
+	//assert.NoError(exists("s3_https_access/cloudformation/policy.rego"))
+	//assert.NoError(exists("s3_https_access/terraform/policy.rego"))
+
+	// check test policies exist
+	assert.NoError(exists("s3_block_public_access/cloudformation/tests/policy_test.rego"))
+	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_read/cloudformation/tests/policy_test.rego"))
+	//assert.NoError(exists("s3_cloudtrail_s3_data_logging_write/cloudformation/tests/policy_test.rego"))
+	assert.NoError(exists("s3_encryption/cloudformation/tests/policy_test.rego"))
+	//assert.NoError(exists("s3_https_access/cloudformation/tests/policy_test.rego"))
+
+	// check relevant input files exist
+	assert.NoError(exists("s3_block_public_access/cloudformation/tests/inputs/invalid_block_public_access_infra.yaml"))
+	assert.NoError(exists("s3_block_public_access/cloudformation/tests/inputs/invalid_block_public_access_infra_yaml.rego"))
+	assert.NoError(exists("s3_block_public_access/cloudformation/tests/inputs/valid_block_public_access_infra.yaml"))
+	assert.NoError(exists("s3_block_public_access/cloudformation/tests/inputs/valid_block_public_access_infra_yaml.rego"))
 }
+

--- a/pkg/policy/policyimporter/test/policy_import_test.go
+++ b/pkg/policy/policyimporter/test/policy_import_test.go
@@ -1,17 +1,17 @@
 package test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/soluble-ai/soluble-cli/pkg/policy/policyimporter"
 	"github.com/soluble-ai/soluble-cli/pkg/policy/testutil"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func cleanUp() {
 	os.RemoveAll("testdata/tmp")
 }
-
 
 func exists(file string) error {
 	_, err := os.Stat("testdata/tmp/policies/opal/" + file)
@@ -24,15 +24,15 @@ func Test_converter(t *testing.T) {
 	defer cleanUp()
 
 	converter := &policyimporter.Converter{
-		OpalRegoPath :  "testdata/input/policies",
-		DestPath: "testdata/tmp/policies/opal",
-		TestPath: "testdata/input/policiesTest/tests/policies",
+		OpalRegoPath: "testdata/input/policies",
+		DestPath:     "testdata/tmp/policies/opal",
+		TestPath:     "testdata/input/policiesTest/tests/policies",
 	}
 	if err := converter.ConvertOpalBuiltIns(); err != nil {
 		t.Fail()
 	}
 
-	//test metadata
+	// test metadata
 	expectedFilePath := "testdata/expected/metadata.yaml"
 	actualFilePath := "testdata/tmp/policies/opal/s3_https_access/metadata.yaml"
 	diff := testutil.CompareYamlFiles(actualFilePath, expectedFilePath)
@@ -53,4 +53,3 @@ func Test_converter(t *testing.T) {
 	assert.NoError(exists("s3_block_public_access/cloudformation/tests/inputs/valid_block_public_access_infra.yaml"))
 	assert.NoError(exists("s3_block_public_access/cloudformation/tests/inputs/valid_block_public_access_infra_yaml.rego"))
 }
-

--- a/pkg/policy/policyimporter/test/testdata/input/policies/cfn/s3/block_public_access.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policies/cfn/s3/block_public_access.rego
@@ -1,0 +1,44 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package policies.cfn_s3_block_public_access
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_1.20"
+      ],
+      "CIS-AWS_v1.4.0": [
+        "CIS-AWS_v1.4.0_2.1.5"
+      ]
+    },
+    "severity": "High"
+  },
+  "description": "S3 buckets should have all `block public access` options enabled. AWS's S3 Block Public Access feature has four settings: BlockPublicAcls, IgnorePublicAcls, BlockPublicPolicy, and RestrictPublicBuckets. All four settings should be enabled to help prevent the risk of a data breach.",
+  "id": "FG_R00229",
+  "title": "S3 buckets should have all `block public access` options enabled"
+}
+
+input_type := "cfn"
+resource_type := "AWS::S3::Bucket"
+
+default allow = false
+
+allow {
+  access_block := input.PublicAccessBlockConfiguration
+  access_block.BlockPublicAcls == true
+  access_block.BlockPublicPolicy == true
+  access_block.IgnorePublicAcls == true
+  access_block.RestrictPublicBuckets == true
+}

--- a/pkg/policy/policyimporter/test/testdata/input/policies/cfn/s3/encryption.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policies/cfn/s3/encryption.rego
@@ -1,0 +1,40 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package policies.cfn_s3_encryption
+
+__rego__metadoc__ := {
+  "custom": {
+    "controls": {
+      "CIS-AWS_v1.3.0": [
+        "CIS-AWS_v1.3.0_2.1.1"
+      ]
+    },
+    "severity": "High"
+  },
+  "description": "S3 bucket server side encryption should be enabled. Enabling server-side encryption (SSE) on S3 buckets at the object level protects data at rest and helps prevent the breach of sensitive information assets. Objects can be encrypted with S3-Managed Keys (SSE-S3), KMS-Managed Keys (SSE-KMS), or Customer-Provided Keys (SSE-C).",
+  "id": "FG_R00099",
+  "title": "S3 bucket server side encryption should be enabled"
+}
+
+input_type := "cfn"
+resource_type := "AWS::S3::Bucket"
+
+default allow = false
+
+allow {
+  algorithms := [algorithm |
+    algorithm := input.BucketEncryption.ServerSideEncryptionConfiguration[_].ServerSideEncryptionByDefault.SSEAlgorithm
+  ]
+  count(algorithms) > 0
+}

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/block_public_access_test.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/block_public_access_test.rego
@@ -1,0 +1,27 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package policies.cfn_s3_block_public_access
+
+import data.tests.policies.cfn.s3.inputs
+
+test_valid {
+    resources = inputs.valid_block_public_access_infra_yaml.mock_resources
+    allow with input as resources["Bucket"]
+}
+
+test_invalid {
+    resources = inputs.invalid_block_public_access_infra_yaml.mock_resources
+    not allow with input as resources["Bucket1"]
+    not allow with input as resources["Bucket2"]
+}

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/encryption_test.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/encryption_test.rego
@@ -1,0 +1,32 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package policies.cfn_s3_encryption
+
+import data.tests.policies.cfn.s3.inputs
+
+test_valid_encryption {
+    resources = inputs.valid_encryption_infra_yaml.mock_resources
+    allow with input as resources["Bucket"]
+}
+
+test_invalid_encryption_missing {
+    resources = inputs.invalid_encryption_missing_infra_yaml.mock_resources
+    not allow with input as resources["Bucket"]
+}
+
+test_invalid_encryption_with_valid {
+    resources = inputs.invalid_encryption_with_valid_infra_yaml.mock_resources
+    allow with input as resources["Bucket"]
+    not allow with input as resources["InvalidBucket"]
+}

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_block_public_access_infra.yaml
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_block_public_access_infra.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Invalid S3 block public access configuration
+Resources:
+  Bucket1:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+  Bucket2:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_block_public_access_infra_yaml.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_block_public_access_infra_yaml.rego
@@ -1,0 +1,45 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package tests.policies.cfn.s3.inputs.invalid_block_public_access_infra_yaml
+
+import data.lacework.resource_view.resource_view_input
+
+mock_input := ret {
+  ret = resource_view_input with input as mock_config
+}
+mock_resources := mock_input.resources
+mock_config := {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Invalid S3 block public access configuration",
+  "Resources": {
+    "Bucket1": {
+      "Properties": {
+        "AccessControl": "Private"
+      },
+      "Type": "AWS::S3::Bucket"
+    },
+    "Bucket2": {
+      "Properties": {
+        "AccessControl": "Private",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        }
+      },
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}
+

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_missing_infra.yaml
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_missing_infra.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Invalid S3 encryption configuration
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_missing_infra_yaml.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_missing_infra_yaml.rego
@@ -1,0 +1,31 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package tests.policies.cfn.s3.inputs.invalid_encryption_missing_infra_yaml
+
+import data.lacework.resource_view.resource_view_input
+
+mock_input := ret {
+  ret = resource_view_input with input as mock_config
+}
+mock_resources := mock_input.resources
+mock_config := {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Invalid S3 encryption configuration",
+  "Resources": {
+    "Bucket": {
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}
+

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_with_valid_infra.yaml
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_with_valid_infra.yaml
@@ -1,0 +1,41 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Invalid and valid S3 encryption configurations
+Resources:
+  KMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: This key is used to encrypt bucket objects
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "default-key-policy"
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+      PendingWindowInDays: 10
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID: !Ref KMSKey
+              SSEAlgorithm: aws:kms
+  InvalidBucket:
+    Type: AWS::S3::Bucket

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_with_valid_infra_yaml.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/invalid_encryption_with_valid_infra_yaml.rego
@@ -1,0 +1,72 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package tests.policies.cfn.s3.inputs.invalid_encryption_with_valid_infra_yaml
+
+import data.lacework.resource_view.resource_view_input
+
+mock_input := ret {
+  ret = resource_view_input with input as mock_config
+}
+mock_resources := mock_input.resources
+mock_config := {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Invalid and valid S3 encryption configurations",
+  "Resources": {
+    "Bucket": {
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": {
+                  "Ref": "KMSKey"
+                },
+                "SSEAlgorithm": "aws:kms"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::S3::Bucket"
+    },
+    "InvalidBucket": {
+      "Type": "AWS::S3::Bucket"
+    },
+    "KMSKey": {
+      "Properties": {
+        "Description": "This key is used to encrypt bucket objects",
+        "KeyPolicy": {
+          "Id": "default-key-policy",
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root"
+                }
+              },
+              "Resource": "*",
+              "Sid": "Enable IAM User Permissions"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PendingWindowInDays": 10
+      },
+      "Type": "AWS::KMS::Key"
+    }
+  }
+}
+

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_block_public_access_infra.yaml
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_block_public_access_infra.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Valid S3 block public access configuration
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_block_public_access_infra_yaml.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_block_public_access_infra_yaml.rego
@@ -1,0 +1,40 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package tests.policies.cfn.s3.inputs.valid_block_public_access_infra_yaml
+
+import data.lacework.resource_view.resource_view_input
+
+mock_input := ret {
+  ret = resource_view_input with input as mock_config
+}
+mock_resources := mock_input.resources
+mock_config := {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Valid S3 block public access configuration",
+  "Resources": {
+    "Bucket": {
+      "Properties": {
+        "AccessControl": "Private",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        }
+      },
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}
+

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_encryption_infra.yaml
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_encryption_infra.yaml
@@ -1,0 +1,39 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Valid S3 encryption configuration
+Resources:
+  KMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: This key is used to encrypt bucket objects
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "default-key-policy"
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+      PendingWindowInDays: 10
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID: !Ref KMSKey
+              SSEAlgorithm: aws:kms

--- a/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_encryption_infra_yaml.rego
+++ b/pkg/policy/policyimporter/test/testdata/input/policiesTest/tests/policies/cfn/s3/inputs/valid_encryption_infra_yaml.rego
@@ -1,0 +1,69 @@
+# Copyright 2022 Lacework, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package tests.policies.cfn.s3.inputs.valid_encryption_infra_yaml
+
+import data.lacework.resource_view.resource_view_input
+
+mock_input := ret {
+  ret = resource_view_input with input as mock_config
+}
+mock_resources := mock_input.resources
+mock_config := {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Valid S3 encryption configuration",
+  "Resources": {
+    "Bucket": {
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": {
+                  "Ref": "KMSKey"
+                },
+                "SSEAlgorithm": "aws:kms"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::S3::Bucket"
+    },
+    "KMSKey": {
+      "Properties": {
+        "Description": "This key is used to encrypt bucket objects",
+        "KeyPolicy": {
+          "Id": "default-key-policy",
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root"
+                }
+              },
+              "Resource": "*",
+              "Sid": "Enable IAM User Permissions"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PendingWindowInDays": 10
+      },
+      "Type": "AWS::KMS::Key"
+    }
+  }
+}
+


### PR DESCRIPTION
### JIRA
> https://lacework.atlassian.net/browse/RAIN-39247

### Description
> Add `ARM` to `alltargets` var to allow `policy vet` to vet all targets in the iac-content repo
> Add test policy conversion 