### PR TITLE
feat(RAIN-39306) CLI policy upload/download support

### DIFF
--- a/cmd/tfscan/tfscan.go
+++ b/cmd/tfscan/tfscan.go
@@ -43,7 +43,7 @@ Scans terraform code with checkov.  Use a sub-command to explicitly choose a sca
 		}),
 		scan,
 	)
-	opal := tools.CreateCommand(&opal.Tool{})
+	opal := tools.CreateCommand(&opal.Tool{InputType: "tf"})
 	opal.Hidden = true
 	c.AddCommand(opal)
 	return c

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -21,11 +21,11 @@ func (t mockPolicyType) PreparePolicies(policies []*Policy, dest string) error {
 }
 
 func TestResolvePolicyIDOkay(t *testing.T) {
-	assertPolicyIDOkay(t, newStore(), "a_test_policy", "c-mock-a-test-policy")
+	assertPolicyIDOkay(t, newTestStore(), "a_test_policy", "c-mock-a-test-policy")
 }
 
 func TestResolvePolicyIDExists(t *testing.T) {
-	store := newStore()
+	store := newTestStore()
 	path := "a_test_policy"
 	assertPolicyIDOkay(t, store, path, "c-mock-a-test-policy")
 	policyID, err := store.resolvePolicyID(mockPolicyType{}, path)
@@ -40,7 +40,7 @@ func assertPolicyIDOkay(t *testing.T, store *Store, path string, expected string
 	assert.Nil(t, err)
 }
 
-func newStore() *Store {
+func newTestStore() *Store {
 	return &Store{
 		PolicyIds: make(map[string]string),
 	}

--- a/pkg/xcp/xcp.go
+++ b/pkg/xcp/xcp.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/soluble-ai/go-jnode"
@@ -211,6 +212,7 @@ func GetCIEnv(dir string) map[string]string {
 		values["SOLUBLE_METADATA_HOSTNAME"] = h
 	}
 
+	values["POLICY_METADATA_UPLOAD_TIME"] = time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	return values
 }
 


### PR DESCRIPTION
  On upload we create the root policy dirs 'policies/{module}' and write these as tar entries
  to ensure we set permissions and mod time.

  On upload we also do the policyId/sid rewrite

  Download now downloads a tar of tars and extracts these to the users latest policies dir.
  These changes extract those tars within that dir combining customer and lacework policies.
  When running a scan we do not rewrite the policyId/sid, these have been validated and corrected
  by the api server and the metadata.yaml contains the values that should be used in a scan.

Signed-off-by: Martin Scott <martin.scott@lacework.net>