### PR TITLE
Lacework CLI compatbility changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
       env:
         SOLUBLE_API_TOKEN: ${{ secrets.SOLUBLE_API_TOKEN }}
         SOLUBLE_API_SERVER: https://api.demo.soluble.cloud
+        SOLUBLE_ORGANIZATION: "114816640272"
     - name: Caching docker images for test
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -28,10 +28,13 @@ func Command() *cobra.Command {
 		Use:   "auth",
 		Short: "Manage authentication",
 	}
-	c.AddCommand(profileCmd(),
-		printTokenCmd(),
-		setAccessTokenCmd(),
-	)
+	c.AddCommand(profileCmd())
+	if !config.IsRunningAsComponent() {
+		c.AddCommand(
+			printTokenCmd(),
+			setAccessTokenCmd(),
+		)
+	}
 	return c
 }
 
@@ -85,9 +88,10 @@ func setAccessTokenCmd() *cobra.Command {
 	opts := options.PrintClientOpts{}
 	var accessToken string
 	c := &cobra.Command{
-		Use:   "set-access-token",
-		Short: "Add an access token",
-		Args:  cobra.NoArgs,
+		Use:         "set-access-token",
+		Short:       "Add an access token",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{config.ConfigurationNotRequired: "1"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config.Config.APIToken = accessToken
 			cfg, err := opts.GetAPIClientConfig()
@@ -113,7 +117,7 @@ func setAccessTokenCmd() *cobra.Command {
 		},
 	}
 	opts.Register(c)
-	c.Flags().StringVar(&accessToken, "access-token", "", "The access token from ")
+	c.Flags().StringVar(&accessToken, "access-token", "", "The legacy IAC access `token`")
 	_ = c.MarkFlagRequired("access-token")
 	return c
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -81,6 +81,11 @@ func Command() *cobra.Command {
 			if profile != "" {
 				config.SelectProfile(profile)
 			}
+			if config.IsConfigurationRequired(cmd) {
+				if err := config.Config.ValidateConfiguration(); err != nil {
+					return err
+				}
+			}
 			if workingDir != "" {
 				if err := os.Chdir(workingDir); err != nil {
 					return err
@@ -100,8 +105,8 @@ func Command() *cobra.Command {
 	}
 
 	flags := rootCmd.PersistentFlags()
-	flags.StringVar(&profile, "profile", "", "Use this configuration profile (see 'config list-profiles')")
-	flags.StringVar(&setProfile, "set-profile", "", "Set the current profile to this (and save it.)")
+	flags.StringVar(&profile, "iac-profile", "", "Use this configuration profile (see 'config list-profiles')")
+	flags.StringVar(&setProfile, "set-iac-profile", "", "Set the current profile to this (and save it.)")
 	log.AddFlags(flags)
 	flags.StringVar(&workingDir, "working-dir", "", "Change the working dir to `dir` before running")
 	flags.Lookup("working-dir").Hidden = true
@@ -114,6 +119,13 @@ func Command() *cobra.Command {
 	}
 	setupHelp(rootCmd)
 	return rootCmd
+}
+
+func SetAnnotation(cmd *cobra.Command, name, value string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[name] = value
 }
 
 func addBuiltinCommands(rootCmd *cobra.Command) {

--- a/cmd/test/command.go
+++ b/cmd/test/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/soluble-ai/go-jnode"
 	"github.com/soluble-ai/soluble-cli/cmd/root"
+	"github.com/soluble-ai/soluble-cli/pkg/config"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/util"
 	"gopkg.in/yaml.v3"
@@ -31,6 +32,12 @@ func NewCommand(t *testing.T, args ...string) *Command {
 
 func (c *Command) Run() error {
 	color.NoColor = true
+	config.Load()
+	if !strings.HasSuffix(config.Config.ProfileName, "-test") {
+		c.T.Log("Integration testing requires running with a profile that ends with -test")
+		c.T.Log("(You can copy an existing profile with \"... configure set-profile demo-test --copy-from demo\")")
+		c.T.FailNow()
+	}
 	wd, err := os.Getwd()
 	util.Must(err)
 	log.Infof("Running command {primary:%s} {secondary:with --working-dir %s}", strings.Join(c.Args, " "), wd)

--- a/cmd/test/require.go
+++ b/cmd/test/require.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/soluble-ai/soluble-cli/pkg/config"
@@ -12,10 +11,5 @@ func RequireAPIToken(t *testing.T) {
 	config.Load()
 	if config.Config.APIToken == "" {
 		t.Skip("test requires authentication")
-	}
-	if !strings.HasSuffix(config.Config.ProfileName, "-test") {
-		t.Log("Integration testing requires running with a profile that ends with -test")
-		t.Log("(You can copy an existing profile with \"... configure set-profile demo-test --copy-from demo\")")
-		t.FailNow()
 	}
 }

--- a/hack/lacework.sh
+++ b/hack/lacework.sh
@@ -5,10 +5,10 @@
 
 set -euo pipefail
 
-export LW_ACCOUNT=$(lacework configure show account)
-export LW_API_KEY=$(lacework configure show api_key)
-export LW_API_SECRET=$(lacework configure show api_secret)
-export LW_API_TOKEN=$(lacework access-token)
+export LW_ACCOUNT=$(set -e; lacework configure show account)
+export LW_API_KEY=$(set -e;lacework configure show api_key)
+export LW_API_SECRET=$(set -e; lacework configure show api_secret)
+export LW_API_TOKEN=$(set -e; lacework access-token)
 export LW_COMPONENT_NAME=iac
 
 exec go run main.go "$@"

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -1,0 +1,13 @@
+package config
+
+import "github.com/spf13/cobra"
+
+const ConfigurationNotRequired = "ConfigurationNotRequired"
+
+func IsConfigurationRequired(cmd *cobra.Command) bool {
+	if cmd.Run == nil && cmd.RunE == nil {
+		// command groups don't require configuration
+		return false
+	}
+	return cmd.Annotations["ConfigurationNotRequired"] == ""
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -49,7 +49,8 @@ func TestConfig(t *testing.T) {
 	if GlobalConfig.CurrentProfile != "test" || Config.APIToken != "yyy" {
 		t.Error(GlobalConfig)
 	}
-	if strings.Contains(Config.String(), "yyy") {
+	n := Config.PrintableJSON()
+	if strings.Contains(n.Path("APIToken").AsText(), "yyy") {
 		t.Error(Config)
 	}
 	_ = Set("tlsnoverify", "true")

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -33,10 +33,12 @@ var (
 )
 
 func AddFlags(flags *pflag.FlagSet) {
+	// the lacework CLI passes LW_LOG and LW_NOCOLOR, so we'll use
+	// those as the default
 	flags.BoolVar(&trace, "trace", false, "Run with trace logging")
-	flags.BoolVar(&debug, "debug", false, "Run with debug logging")
+	flags.BoolVar(&debug, "debug", os.Getenv("LW_LOG") == "DEBUG", "Run with debug logging")
 	flags.BoolVar(&quiet, "quiet", false, "Run with no logging")
-	flags.BoolVar(&color.NoColor, "no-color", false, "Disable color output")
+	flags.BoolVar(&color.NoColor, "no-color", os.Getenv("LW_NOCOLOR") == "true", "Disable color output")
 	flags.BoolVar(&forceColor, "force-color", false, "Enable color output")
 	flags.BoolVar(&logStdout, "log-stdout", false, "Force the CLI to log to stdout")
 	flags.BoolVar(&logStderr, "log-stderr", false, "Force the CLI to log to stderr")

--- a/pkg/options/client_opts.go
+++ b/pkg/options/client_opts.go
@@ -58,8 +58,8 @@ func (opts *ClientOpts) GetClientOptionsGroup() *HiddenOptionsGroup {
 			flags.Float64Var(&opts.RetryWaitSeconds, "api-retry-wait", 0,
 				"The initial time in `seconds` to wait between retry attempts, e.g. 0.5 to wait 500 millis")
 			flags.StringSliceVar(&opts.Headers, "api-header", nil, "Set custom headers in the form `name:value` on requests")
-			flags.StringVar(&opts.Organization, "organization", "", "The IAC organization `id` to use (by default $LW_IAC_ORGANIZATION if set.)")
-			flags.StringVar(&opts.APIToken, "api-token", "", "The legacy authentication `token` (read from profile by default)")
+			flags.StringVar(&opts.Organization, "iac-organization", "", "The IAC organization `id` to use (by default $LW_IAC_ORGANIZATION if set.)")
+			flags.StringVar(&opts.APIToken, "iac-api-token", "", "The legacy authentication `token` (read from profile by default)")
 			flags.StringVar(&opts.Domain, "api-domain", "", "The Lacework account domain")
 		},
 	}

--- a/pkg/options/print.go
+++ b/pkg/options/print.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/soluble-ai/go-jnode"
+	"github.com/soluble-ai/soluble-cli/pkg/config"
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/options/templates"
 	"github.com/soluble-ai/soluble-cli/pkg/print"
@@ -69,7 +70,13 @@ func (p *PrintOpts) GetPrintOptionsGroup() *HiddenOptionsGroup {
 		CreateFlagsFunc: func(flags *pflag.FlagSet) {
 			flags.StringSliceVar(&p.Template, "print-template", nil,
 				"Print the output with a go `template`.  The template argument may begin with @ in which case the template is read from a file.  If the argument is in the format tmpl=file, then write the output to a file.  May be repeated.")
-			flags.StringSliceVar(&p.OutputFormat, "format", nil,
+			var defaultOutputFormat []string
+			if config.IsRunningAsComponent() {
+				if os.Getenv("LW_JSON") == "true" {
+					defaultOutputFormat = []string{"json"}
+				}
+			}
+			flags.StringSliceVar(&p.OutputFormat, "format", defaultOutputFormat,
 				"Use this output `format` where format is one of: table, yaml, json, none, csv, atlantis, count, or value(name).  If the argument is in the form format=file, then write the output to a file.  May be repeated.")
 			flags.BoolVar(&p.NoHeaders, "no-headers", false, "Omit headers when printing tables or csv")
 			flags.StringSliceVar(&p.Filter, "filter", nil, "Print results that match a `filter`.  May be repeated.")

--- a/pkg/tools/assessment.go
+++ b/pkg/tools/assessment.go
@@ -14,7 +14,6 @@ import (
 	"github.com/soluble-ai/soluble-cli/pkg/log"
 	"github.com/soluble-ai/soluble-cli/pkg/print"
 	"github.com/soluble-ai/soluble-cli/pkg/util"
-	"github.com/soluble-ai/soluble-cli/pkg/xcp"
 )
 
 const AssessmentDirectoryValue = "ASSESSMENT_DIRECTORY"
@@ -132,12 +131,10 @@ func processResult(result *Result) error {
 			if result.Assessment.Failed {
 				exit.Code = 2
 				a := result.Assessment
-				if xcp.GetCISystem() == "" {
-					exit.AddFunc(func() {
-						log.Errorf("Exiting with error because {warning:%s} has {danger:%d %s findings}",
-							a.Title, a.FailedCount, a.FailedSeverity)
-					})
-				}
+				exit.AddFunc(func() {
+					log.Errorf("Exiting with error because {warning:%s} has {danger:%d %s findings}",
+						a.Title, a.FailedCount, a.FailedSeverity)
+				})
 			}
 		}
 	}


### PR DESCRIPTION
* Change the --organization flag to --iac-organization

* Change the --profile and --set-profile flags to --iac-profile and --set-iac-profile

* Don't show the auth print-token or auth set-access-token commands when invoked with the lacework CLI

* Add a --reconfigure flag to the configure command to allow reconfiguration (i.e. choosing lacework profile and organization.)

* Integration tests now require a profile that ends in -test or they will fail, even for commands that do --upload=false.

* Save ConfiguredAccount in config file so we can detect when the lacework profile changes

* Verify the configuration is valid and suggest fixes

* Log a little about whether or not lacework auth or legacy soluble auth is used

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>