### PR TITLE
Bring back code to read only the first part of large files for inventory

### DIFF
--- a/pkg/inventory/cloudformation.go
+++ b/pkg/inventory/cloudformation.go
@@ -29,8 +29,8 @@ func (cloudformationDetector) DetectFileName(m *Manifest, path string) ContentDe
 	return nil
 }
 
-func (cloudformationDetector) DetectContent(m *Manifest, path string, buf []byte) {
-	d := decodeDocument(path, buf)
+func (cloudformationDetector) DetectContent(m *Manifest, path string, content *Content) {
+	d := content.DecodeDocument()
 	if _, ok := d["AWSTemplateFormatVersion"]; ok {
 		m.CloudformationFiles.Add(path)
 	}

--- a/pkg/inventory/cloudformation_test.go
+++ b/pkg/inventory/cloudformation_test.go
@@ -32,11 +32,15 @@ AWSTemplateFormatVersion: '2010-09-09'`, true},
 	d := cloudformationDetector(0)
 	for _, tc := range testCases {
 		m := &Manifest{}
-		d.DetectContent(m, tc.name, []byte(tc.content))
+		content := &Content{
+			path: tc.name,
+			Head: []byte(tc.content),
+		}
+		d.DetectContent(m, tc.name, content)
 		if tc.match && (m.CloudformationFiles.Len() != 1 || m.CloudformationFiles.Get(0) != tc.name) {
-			t.Error(tc)
+			t.Error(tc, m.CloudformationFiles)
 		} else if !tc.match && m.CloudformationFiles.Len() != 0 {
-			t.Error(tc)
+			t.Error(tc, m.CloudformationFiles)
 		}
 	}
 }

--- a/pkg/inventory/content_test.go
+++ b/pkg/inventory/content_test.go
@@ -1,7 +1,6 @@
 package inventory
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,9 +8,9 @@ import (
 
 func TestDecode(t *testing.T) {
 	assert := assert.New(t)
-	d, err := os.ReadFile("testdata/example.yaml")
+	d, err := readContent("testdata/example.yaml", make([]byte, 8192))
 	if assert.NoError(err) {
-		m := decodeDocument("example.yaml", d)
+		m := d.DecodeDocument()
 		assert.Contains(m, "greeting")
 	}
 }

--- a/pkg/inventory/docker.go
+++ b/pkg/inventory/docker.go
@@ -31,8 +31,8 @@ func (d dockerDetector) DetectFileName(m *Manifest, path string) ContentDetector
 	return nil
 }
 
-func (dockerDetector) DetectContent(m *Manifest, path string, content []byte) {
-	if strings.Contains(string(content), "FROM ") {
+func (dockerDetector) DetectContent(m *Manifest, path string, content *Content) {
+	if strings.Contains(string(content.Head), "FROM ") {
 		m.DockerDirectories.Add(filepath.Dir(path))
 		m.Dockerfiles.Add(path)
 	}

--- a/pkg/inventory/kubernetes.go
+++ b/pkg/inventory/kubernetes.go
@@ -39,8 +39,8 @@ func (kubernetesDetector) DetectFileName(m *Manifest, path string) ContentDetect
 	return nil
 }
 
-func (kubernetesDetector) DetectContent(m *Manifest, path string, content []byte) {
-	d := decodeDocument(path, content)
+func (kubernetesDetector) DetectContent(m *Manifest, path string, content *Content) {
+	d := content.DecodeDocument()
 	if filepath.Base(path) == "Chart.yaml" && d["apiVersion"] != "" {
 		// Looks like a helm chart
 		m.HelmCharts.Add(filepath.Dir(path))

--- a/pkg/inventory/terraform.go
+++ b/pkg/inventory/terraform.go
@@ -53,13 +53,13 @@ func (d *terraformDetector) DetectFileName(m *Manifest, path string) ContentDete
 	return nil
 }
 
-func (*terraformDetector) DetectContent(m *Manifest, path string, content []byte) {
+func (*terraformDetector) DetectContent(m *Manifest, path string, content *Content) {
 	if strings.HasSuffix(path, ".tf") {
-		if providerRegexp.Find(content) != nil {
+		if providerRegexp.Find(content.Head) != nil {
 			m.TerraformRootModules.Add(filepath.Dir(path))
 		}
 	} else {
-		p := gjson.ParseBytes(content).Get("provider")
+		p := gjson.ParseBytes(content.Head).Get("provider")
 		if p.IsArray() || p.IsObject() {
 			m.TerraformRootModules.Add(filepath.Dir(path))
 		}


### PR DESCRIPTION
* Avoid decoding docs more than once

* Read first 1mb of files at most

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>