### PR TITLE
Fix help text in a couple of places

### DIFF
--- a/pkg/options/client_opts.go
+++ b/pkg/options/client_opts.go
@@ -73,7 +73,6 @@ The following environment variables are also supported:
 					"The soluble organization `id` to use.  Overrides the value of --iac-organization.")
 			}
 			flags.StringVar(&opts.APIConfig.LegacyAPIToken, "iac-api-token", "", "The legacy authentication `token`")
-			flags.StringVar(&opts.APIConfig.LaceworkAccount, "account", "", "The Lacework account")
 		},
 	}
 }

--- a/pkg/options/group.go
+++ b/pkg/options/group.go
@@ -42,6 +42,16 @@ func (group *HiddenOptionsGroup) Register(cmd *cobra.Command) {
 		}
 		cmd.Flags().AddFlag(f)
 	})
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	hog := cmd.Annotations["HiddenOptionGroups"]
+	if hog == "" {
+		hog = group.Name
+	} else {
+		hog = fmt.Sprintf("%s %s", hog, group.Name)
+	}
+	cmd.Annotations["HiddenOptionGroups"] = hog
 }
 
 func (group *HiddenOptionsGroup) GetHelpCommand() *cobra.Command {

--- a/pkg/tools/assessmentopts.go
+++ b/pkg/tools/assessmentopts.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/soluble-ai/soluble-cli/pkg/archive"
+	"github.com/soluble-ai/soluble-cli/pkg/config"
 	"github.com/spf13/afero"
 
 	"github.com/soluble-ai/soluble-cli/pkg/assessments"
@@ -59,16 +60,16 @@ func (o *AssessmentOpts) GetAssessmentHiddenOptions() *options.HiddenOptionsGrou
 	return &options.HiddenOptionsGroup{
 		Name: "tool-options",
 		Long: "Options for running tools",
-		Example: `
+		Example: config.ExpandCommandInvocation(`
 A tool run can optionally exit with exit code 2 if the assessment contains
 failed findings.  For example:
 		
 # Fail if 1 or more high or critical severity findings in this build:
-soluble ... --fail high=1
+{{ .CommandInvocation }} ... --fail high=1
 # Or shorter:
-soluble ... --fail high
+{{ .CommandInvocation }} ... --fail high
 
-The severity levels are critical, high, medium, low, and info in that order.`,
+The severity levels are critical, high, medium, low, and info in that order.`),
 		CreateFlagsFunc: func(flags *pflag.FlagSet) {
 			flags.BoolVar(&o.DisableCustomPolicies, "disable-custom-policies", true, "Don't use custom policies")
 			flags.StringVar(&o.CustomPoliciesDir, "custom-policies", "", "Use custom policies from `dir`.")


### PR DESCRIPTION
* Use "lacework iac" in help text if running as a component

* Remove --account option

* Must use "help --all-options" instead of "help -a"

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>