### PR TITLE
Single kustomize assessment

### DIFF
--- a/pkg/inventory/ci.go
+++ b/pkg/inventory/ci.go
@@ -21,15 +21,21 @@ import (
 
 type cidetector int
 
-var _ FileDetector = cidetector(0)
+var (
+	_ FileDetector = cidetector(0)
+	_ DirDetector  = cidetector(0)
+)
 
-func (cidetector) DetectDirName(m *Manifest, path string) {
+func (cidetector) DetectDirName(m *Manifest, path string) bool {
 	switch path {
 	case ".buildkite":
 		m.CISystems.Add("buildkite")
 	case ".circleci":
 		m.CISystems.Add("circleci")
+	case ".github":
+		return true
 	}
+	return false
 }
 
 func (cidetector) DetectFileName(m *Manifest, path string) ContentDetector {

--- a/pkg/tools/checkov/result_merge.go
+++ b/pkg/tools/checkov/result_merge.go
@@ -1,0 +1,55 @@
+package checkov
+
+import "github.com/soluble-ai/go-jnode"
+
+func mergeResults(dest *jnode.Node, source *jnode.Node) {
+	combineArrays(dest, source, "results", "passed_checks")
+	combineArrays(dest, source, "results", "failed_checks")
+	addSummary(dest, source, "passed")
+	addSummary(dest, source, "failed")
+	addSummary(dest, source, "skipped")
+	addSummary(dest, source, "parsing_errors")
+	addSummary(dest, source, "resource_count")
+}
+
+func combineArrays(dest *jnode.Node, source *jnode.Node, paths ...string) {
+	for i := 1; i < len(paths); i++ {
+		path := paths[i-1]
+		nsource := source.Path(path)
+		if !nsource.IsObject() {
+			return
+		}
+		source = nsource
+		ndest := dest.Path(path)
+		if !ndest.IsObject() {
+			ndest = dest.PutObject(path)
+		}
+		dest = ndest
+	}
+	last := paths[len(paths)-1]
+	darray := dest.Path(last)
+	if !darray.IsArray() {
+		darray = dest.PutArray(last)
+	}
+	sarray := source.Path(last)
+	if sarray.IsArray() {
+		for _, item := range sarray.Elements() {
+			darray.Append(item.Unwrap())
+		}
+	}
+}
+
+func addSummary(dest *jnode.Node, source *jnode.Node, field string) {
+	ssum := source.Path("summary")
+	if !ssum.IsMissing() {
+		s := ssum.Path(field)
+		if s.IsNumber() {
+			dsum := dest.Path("summary")
+			if dsum.IsMissing() {
+				dsum = dest.PutObject("summary")
+			}
+			val := dsum.Path(field).AsInt()
+			dsum.Put(field, val+s.AsInt())
+		}
+	}
+}

--- a/pkg/tools/checkov/result_merge_test.go
+++ b/pkg/tools/checkov/result_merge_test.go
@@ -1,0 +1,32 @@
+package checkov
+
+import (
+	"testing"
+
+	"github.com/soluble-ai/go-jnode"
+	"github.com/soluble-ai/soluble-cli/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCombineArrays(t *testing.T) {
+	assert := assert.New(t)
+	r1 := util.MustReadJSONFile("testdata/results.json.gz")
+	r2 := util.MustReadJSONFile("testdata/results2.json.gz")
+	assert.Equal(6, r1.Path("results").Path("passed_checks").Size())
+	assert.Equal(5, r2.Path("results").Path("passed_checks").Size())
+	combineArrays(r1, r2, "results", "passed_checks")
+	assert.Equal(11, r1.Path("results").Path("passed_checks").Size())
+	n := jnode.NewObjectNode()
+	assert.Equal(1, r1.Path("results").Path("failed_checks").Size())
+	combineArrays(n, r1, "results", "failed_checks")
+	assert.Equal(1, r1.Path("results").Path("failed_checks").Size())
+	combineArrays(n, r1, "foo")
+}
+
+func TestMergeResults(t *testing.T) {
+	assert := assert.New(t)
+	r1 := util.MustReadJSONFile("testdata/results.json.gz")
+	r2 := util.MustReadJSONFile("testdata/results2.json.gz")
+	mergeResults(r1, r2)
+	assert.Equal(17, r1.Path("summary").Path("passed").AsInt())
+}


### PR DESCRIPTION
* kustomize-scan now has an --include flag which enables recursive searching
for kustomize overlays.  Each --include pattern is a gitignore-style; e.g.
--include '**' will run checkov against all recursively discovered kustomize
overlays under the target directory.

* inventory will ignore directories that start with .