### PR TITLE
Couple of small fixes to configure

### DIFF
--- a/cmd/configure/command.go
+++ b/cmd/configure/command.go
@@ -251,14 +251,14 @@ func (o *switchProfileOptions) saveValues(cmd *cobra.Command) error {
 	}
 	if flags.Changed("iac-organization") {
 		api.Organization = o.APIConfig.Organization
-		if api.Organization == "" {
-			if err := o.ConfigureDefaultOrganization(); err != nil {
-				return err
-			}
-		} else {
-			if err := o.ValidateOrganization(); err != nil {
-				return err
-			}
+	}
+	if api.Organization == "" {
+		if err := o.ConfigureDefaultOrganization(); err != nil {
+			return err
+		}
+	} else {
+		if err := o.ValidateOrganization(); err != nil {
+			return err
 		}
 	}
 	cfg := config.Get()

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -125,6 +125,7 @@ func uploadCommand() *cobra.Command {
 		m          manager.M
 		zipArchive string
 		uploadOpts tools.UploadOpts
+		allowEmpty bool
 	)
 	c := &cobra.Command{
 		Use:   "upload",
@@ -137,6 +138,9 @@ func uploadCommand() *cobra.Command {
 			}
 			if err := m.LoadPolicies(); err != nil {
 				return err
+			}
+			if len(m.Policies) == 0 && !allowEmpty {
+				return fmt.Errorf("no policies found, use --allow-empty to upload no policies")
 			}
 			if res := m.ValidatePolicies(); res.Errors != nil {
 				return res.Errors
@@ -180,9 +184,9 @@ func uploadCommand() *cobra.Command {
 	uploadOpts.DefaultUploadEnabled = true
 	uploadOpts.Register(c)
 	flags.StringVar(&zipArchive, "save-zip-file", "", "Save the upload zip archive to `file`.  By default the archive is written to a temporary file.")
+	flags.BoolVar(&allowEmpty, "allow-empty", false, "Allow upload of no policies.")
 	flags.Lookup("upload").Usage = "Upload policies to lacework.  Use --upload=false to skip uploading."
 	flags.Lookup("upload-errors").Hidden = true // doesn't make sense here
-	_ = c.MarkFlagRequired("directory")
 	return c
 }
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -228,7 +228,6 @@ func setupSimulatedComponentEnv() error {
 	if config.IsRunningAsComponent() {
 		return nil
 	}
-	log.Infof("Setting up environment to simulate component execution")
 	var (
 		account   string
 		apiKey    string
@@ -249,6 +248,7 @@ func setupSimulatedComponentEnv() error {
 	if err != nil {
 		return err
 	}
+	log.Infof("Setting up environment to simulate component execution with account {info:%s}", account)
 	os.Setenv("LW_ACCOUNT", account)
 	os.Setenv("LW_API_KEY", apiKey)
 	os.Setenv("LW_API_SECRET", apiSecret)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,6 +189,7 @@ func (c *ProfileT) Reset() {
 	name := c.ProfileName
 	*c = ProfileT{
 		ProfileName: name,
+		APIServer:   "https://api.soluble.cloud",
 	}
 }
 

--- a/pkg/policy/manager/manager.go
+++ b/pkg/policy/manager/manager.go
@@ -57,7 +57,6 @@ func (m *M) Register(cmd *cobra.Command) {
 	m.RunOpts.Register(cmd)
 	flags := cmd.Flags()
 	flags.StringVarP(&m.Dir, "directory", "d", "", "Load policies from this directory")
-	_ = cmd.MarkFlagRequired("directory")
 }
 
 func (m *M) RegisterDownload(cmd *cobra.Command) {


### PR DESCRIPTION
* Make reconfig --reset set api server to default

* Make reconfig choose default org if not set

* For policy commands, default -d to current directory

* Don't upload 0 policies unless --allow-empty

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>