### PR TITLE
RAIN-47779: `policy create` feedback changes

### DIFF
--- a/pkg/policy/custompolicybuilder/policy_template.go
+++ b/pkg/policy/custompolicybuilder/policy_template.go
@@ -48,6 +48,7 @@ var categories = []string{
 	"backup & recovery",
 }
 var gcpResourceTypes = []string{
+	"multiple",
 	"google_bigquery_dataset",
 	"google_compute_instance",
 	"google_dns_managed_zone",
@@ -57,6 +58,7 @@ var gcpResourceTypes = []string{
 }
 
 var azureResourceTypes = []string{
+	"multiple",
 	"azurerm_app_service",
 	"azurerm_role_definition",
 	"azurerm_key_vault",
@@ -74,6 +76,7 @@ var azureResourceTypes = []string{
 	"azurerm_storage_account",
 }
 var awsResourceTypes = []string{
+	"multiple",
 	"aws_api_gateway",
 	"aws_cloudfront_distribution",
 	"aws_cloudTrail",
@@ -194,8 +197,8 @@ func (pt *PolicyTemplate) PromptInput() error {
 		{
 			Name: "rsrcType",
 			Prompt: &survey.Input{
-				Message: "ResourceType\033[37m for suggestions, type aws, google or azure then tab",
-				Help:    "enter custom resource type or type aws, gcp or azure then tab for suggestions",
+				Message: "ResourceType\033[37m for suggestions type aws, google or azure then tab",
+				Help:    "for multiple resource types use multiple",
 				Suggest: func(input string) []string {
 					var suggestions []string
 					switch input {
@@ -205,6 +208,8 @@ func (pt *PolicyTemplate) PromptInput() error {
 						suggestions = gcpResourceTypes
 					case "azure":
 						suggestions = azureResourceTypes
+					case "m":
+						suggestions = append(suggestions, "multiple")
 					}
 					return suggestions
 				},
@@ -409,6 +414,9 @@ func (pt *PolicyTemplate) GeneratePolicyTemplate() error {
 			"\n\ninput_type := \"" + policy.InputTypeForTarget[policy.Target(pt.CheckType)] + "\""
 
 	if pt.RsrcType != "" {
+		if pt.RsrcType == "multiple" {
+			pt.RsrcType = strings.ToUpper(pt.RsrcType)
+		}
 		regoTemplate += "\n\nresource_type := \"" + pt.RsrcType + "\""
 	}
 

--- a/pkg/policy/custompolicybuilder/policy_template.go
+++ b/pkg/policy/custompolicybuilder/policy_template.go
@@ -209,7 +209,7 @@ func (pt *PolicyTemplate) validatePolicyDirectory() func(interface{}) error {
 		} else if dir == "." || dir == "./" {
 			// check current dir is named policies
 			workingDir, _ := os.Getwd()
-			if workingDir != "policies" {
+			if !isPoliciesPath(workingDir) {
 				// offer to create `policies` dir in current dir
 				err := pt.createPoliciesDirectoryPrompt("./policies",
 					"current directory is not named policies. Create policies directory in current directory?")

--- a/pkg/policy/custompolicybuilder/policy_template.go
+++ b/pkg/policy/custompolicybuilder/policy_template.go
@@ -195,8 +195,9 @@ func (pt *PolicyTemplate) validatePolicyDirectory() func(interface{}) error {
 		dir := inputDir.(string)
 		pt.Dir = dir
 
-		// path points to a policies dir
-		if isPoliciesPath(dir) {
+		switch {
+		case isPoliciesPath(dir):
+			// path points to a policies dir
 			// check dir exists
 			if _, err := os.Stat(dir); os.IsNotExist(err) {
 				// if dir doesn't exist offer to create it
@@ -206,7 +207,7 @@ func (pt *PolicyTemplate) validatePolicyDirectory() func(interface{}) error {
 					return err
 				}
 			}
-		} else if dir == "." || dir == "./" {
+		case dir == "." || dir == "./":
 			// check current dir is named policies
 			workingDir, _ := os.Getwd()
 			if !isPoliciesPath(workingDir) {
@@ -217,7 +218,7 @@ func (pt *PolicyTemplate) validatePolicyDirectory() func(interface{}) error {
 					return err
 				}
 			}
-		} else {
+		default:
 			// path does not point to a policies dir
 			// offer to create `policies dir in provided path
 			err := pt.createPoliciesDirectoryPrompt(filepath.Join(dir, "policies"),


### PR DESCRIPTION
### JIRA
https://lacework.atlassian.net/browse/RAIN-47779

### Description
When using the policy create wizard:
Policy directory:
- support current dir as input EG "." and "./"
- if input directory is valid but doesn't exist, offer to create it for the user
- if user has inputed a directory path to the parent of the policies directory, prompt user to confirm correct path with suggestion.

Resource_type: 
- allow user to input custom value
- provide selectable suggestions for aws gcp and azure based on partial input

Category:
- allow custom input
- provide selectable suggestions 

### Test
current tests passing
changes manually tested 
test cases for policies directory field:
- .  (where current dir is named policies and is not)
- ./  (where current dir is named policies and is not)
- policies  (where dir exists and does not exist)
- ./policies  (where dir exists and does not exist)
- path/to/policies  (where dir exists and does not exist)
- path/to (where a policies dir exists and does not exist under this path)