### PR TITLE
RAIN-47784:  Handle json error output from tool

### DIFF
--- a/pkg/tools/assessment.go
+++ b/pkg/tools/assessment.go
@@ -52,7 +52,9 @@ func processResult(result *Result) error {
 		exit.AddFunc(func() {
 			log.Errorf("{primary:%s} has failed - {danger:%s}", o.Tool.Name(), result.ExecuteResult.FailureMessage)
 		})
-		fmt.Fprintln(os.Stderr, result.ExecuteResult.CombinedOutput)
+		if result.ExecuteResult.FailureMessage == "" {
+			fmt.Fprintln(os.Stderr, result.ExecuteResult.CombinedOutput)
+		}
 		if !o.UploadErrors {
 			// If we're not going to upload the errors, then we're done
 			return nil

--- a/pkg/tools/execute_test.go
+++ b/pkg/tools/execute_test.go
@@ -39,3 +39,15 @@ func TestExecuteParseJSON(t *testing.T) {
 	assert.NotNil(n)
 	assert.Equal("world", n.Path("hello").AsText())
 }
+
+func TestExecuteError(t *testing.T) {
+	assert := assert.New(t)
+	failureMessage := "CycleError in aws CycleError: variables form a cycle: aws_instance.nat.provisioner[0].inline"
+	cmd := exec.Command("echo",
+		`{"level":"fatal","msg":"`+failureMessage+`"}`)
+	res := executeCommand(cmd)
+	assert.NotNil(res)
+	assert.Equal(ExecutionFailure, res.FailureType)
+	assert.Equal(failureMessage, res.FailureMessage)
+	assert.False(res.ExpectExitCode(0))
+}


### PR DESCRIPTION
### JIRA
> https://lacework.atlassian.net/browse/RAIN-47784

### Description
Handle the execution error returned from tool (Opal)
(https://github.com/lacework-dev/opal/pull/95)


### Test
current tests passing
Added unit test
tested with current opal and https://github.com/lacework-dev/opal/pull/95