### PR TITLE
RAIN-49577: hide convert command

### DIFF
--- a/cmd/policy/integration/integration_test.go
+++ b/cmd/policy/integration/integration_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/soluble-ai/soluble-cli/cmd/test"
@@ -27,4 +28,11 @@ func TestPolicyTest(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal(4, n.Path("passed").AsInt(), n)
 	assert.Equal(0, n.Path("failed").AsInt(), n)
+}
+
+func TestPolicyConvertHidden(t *testing.T) {
+	test := test.NewCommand(t, "policy", "--help")
+	test.Must(test.Run())
+	assert := assert.New(t)
+	assert.False(strings.Contains(test.Out.String(), "convert"))
 }

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -62,6 +62,9 @@ func opalConvertCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "convert",
 		Short: "Restructure and generate metadata for opal built-in policies to fit lacework directory structure.",
+		// opalConvertCommand is for internal use only
+		// for conversion of regula policies to lacework policies and is not supported.
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			converter := &policyimporter.Converter{}
 			if err := converter.PromptInput(); err != nil {


### PR DESCRIPTION
### JIRA
> https://lacework.atlassian.net/browse/RAIN-49577

### Description
> The convert command is for internal use only.
It can only be used for the internal job of converting the opal built-ins for the iac-content repo.

### Testing
> test added 