### PR TITLE
RAIN-47977: Ensure directory path requirement is clear for policy upload

### DIFF
--- a/cmd/policy/integration/integration_test.go
+++ b/cmd/policy/integration/integration_test.go
@@ -36,3 +36,14 @@ func TestPolicyConvertHidden(t *testing.T) {
 	assert := assert.New(t)
 	assert.False(strings.Contains(test.Out.String(), "convert"))
 }
+
+func TestPolicyUploadFail(t *testing.T) {
+	assert := assert.New(t)
+	test := test.NewCommand(t, "policy", "upload",
+		"-d", "path/to/policies")
+	err := test.Run()
+	assert.Errorf(err,
+		"no policies found."+
+			"\n\t - Ensure path provided points to the parent directory of the /policies directory"+
+			"\n\t - or use --allow-empty to upload no policies.")
+}

--- a/cmd/policy/integration/integration_test.go
+++ b/cmd/policy/integration/integration_test.go
@@ -43,7 +43,7 @@ func TestPolicyUploadFail(t *testing.T) {
 		"-d", "path/to/policies")
 	err := test.Run()
 	assert.Errorf(err,
-		"no policies found."+
+		"no policies found"+
 			"\n\t - Ensure path provided points to the parent directory of the /policies directory"+
-			"\n\t - or use --allow-empty to upload no policies.")
+			"\n\t - or use --allow-empty to upload no policies")
 }

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -145,7 +145,7 @@ func uploadCommand() *cobra.Command {
 			if len(m.Policies) == 0 && !allowEmpty {
 				return fmt.Errorf("no policies found." +
 					"\n\t - Ensure path provided points to the parent directory of the /policies directory" +
-					"\n\t - or use --allow-empty to upload no policies. ")
+					"\n\t - or use --allow-empty to upload no policies.")
 			}
 			if res := m.ValidatePolicies(); res.Errors != nil {
 				return res.Errors

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -143,9 +143,9 @@ func uploadCommand() *cobra.Command {
 				return err
 			}
 			if len(m.Policies) == 0 && !allowEmpty {
-				return fmt.Errorf("no policies found." +
+				return fmt.Errorf("no policies found" +
 					"\n\t - Ensure path provided points to the parent directory of the /policies directory" +
-					"\n\t - or use --allow-empty to upload no policies.")
+					"\n\t - or use --allow-empty to upload no policies")
 			}
 			if res := m.ValidatePolicies(); res.Errors != nil {
 				return res.Errors

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -143,7 +143,9 @@ func uploadCommand() *cobra.Command {
 				return err
 			}
 			if len(m.Policies) == 0 && !allowEmpty {
-				return fmt.Errorf("no policies found, use --allow-empty to upload no policies")
+				return fmt.Errorf("no policies found." +
+					"\n\t - Ensure path provided points to the parent directory of the /policies directory" +
+					"\n\t - or use --allow-empty to upload no policies. ")
 			}
 			if res := m.ValidatePolicies(); res.Errors != nil {
 				return res.Errors
@@ -182,7 +184,7 @@ func uploadCommand() *cobra.Command {
 			return nil
 		},
 	}
-	m.Register(c)
+	m.RegisterUpload(c)
 	flags := c.Flags()
 	uploadOpts.DefaultUploadEnabled = true
 	uploadOpts.Register(c)

--- a/pkg/policy/manager/manager.go
+++ b/pkg/policy/manager/manager.go
@@ -63,6 +63,12 @@ func (m *M) RegisterDownload(cmd *cobra.Command) {
 	m.RunOpts.Register(cmd)
 }
 
+func (m *M) RegisterUpload(cmd *cobra.Command) {
+	m.RunOpts.Register(cmd)
+	flags := cmd.Flags()
+	flags.StringVarP(&m.Dir, "directory", "d", "", "Load policies from this directory. Path should point to the parent directory of your /policies directory.")
+}
+
 func (m *M) ValidatePolicies() ValidateResult {
 	var result ValidateResult
 	for _, policyType := range policy.GetPolicyTypes() {


### PR DESCRIPTION
###JIRA
>  https://lacework.atlassian.net/browse/RAIN-47977

### Description
> When uploading policies, make it clear that the directory path must point to the parent dir of the /policies directory.
> User feedback suggested this was not clear and should be made clear both in the helper function and if an attempted policy upload fails.

### Test
Test added for failed policy upload