### PR TITLE
RAIN-36233: download opal from lacework/opal-releases public repo

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -83,7 +83,6 @@ type urlResolverFunc func(requestedVersion string) (version string, url string, 
 var urlResolvers = map[string]urlResolverFunc{
 	"terraform": terraform.GetVersionAndURL,
 	"tfscore":   gcs.NewResolver("soluble-public", "tfscore"),
-	"opal":      gcs.NewResolver("soluble-public", "opal"),
 }
 
 func NewManager() *Manager {

--- a/pkg/tools/opal/opal.go
+++ b/pkg/tools/opal/opal.go
@@ -72,7 +72,10 @@ func (t *Tool) Run() (*tools.Result, error) {
 		Directory:   t.GetDirectory(),
 		IACPlatform: t.iacPlatform,
 	}
-	d, err := t.InstallTool(&download.Spec{Name: "opal"})
+	d, err := t.InstallTool(&download.Spec{
+		Name: "opal",
+		URL:  "github.com/lacework/opal-releases",
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
###JIRA
https://lacework.atlassian.net/browse/RAIN-36233

###Description
New release process for opal (https://github.com/lacework-dev/opal/pull/106) requires cli change to download opal from https://github.com/lacework/opal-releases

###Test
existing tests pass
cli downloads expected version of opal 