### PR TITLE
chore(COD-354) remove build job placeholder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ on:
     branches: [ master]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - run: | 
-        echo "Temp placeholder for previous required check"
   tests:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ dist: ## build binary with optional file extension (ext) and package (pkg) for g
 	$(eval name=soluble_$(VERSION)_$(os)_$(arch))
 	@echo "Packaging $(name)"
 	@if [ "$(pkg)" = "tar" ]; then \
-		tar cvf ./dist/$(name).tar.gz --use-compress-program='gzip -9' -C target/$(os)_$(arch) .; \
+		tar cvf ./dist/$(name).tar.gz --use-compress-program='gzip -9' --strip-components=1 -C target/$(os)_$(arch) .; \
 	elif [ "$(pkg)" = "zip" ]; then \
 		zip -j ./dist/$(name).zip target/$(os)_$(arch)/*; \
 	fi


### PR DESCRIPTION
The build job has been removed as a required check and this removes the build placeholder from the CI workflow.
Required checks are now `tests` and `package`