### PR TITLE
fix(COD-354) ubuntu latest tar only honours --strip-componenets on ex…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ dist: ## build binary with optional file extension (ext) and package (pkg) for g
 	$(eval name=soluble_$(VERSION)_$(os)_$(arch))
 	@echo "Packaging $(name)"
 	@if [ "$(pkg)" = "tar" ]; then \
-		tar cvf ./dist/$(name).tar.gz --use-compress-program='gzip -9' --strip-components=1 -C target/$(os)_$(arch) .; \
+		pushd . && cd target/$(os)_$(arch) && tar cvf ../../dist/$(name).tar.gz --use-compress-program='gzip -9' * && popd; \
 	elif [ "$(pkg)" = "zip" ]; then \
 		zip -j ./dist/$(name).zip target/$(os)_$(arch)/*; \
 	fi


### PR DESCRIPTION
…tract, --transform appears to not work, -C prepends ./ . Change the directory to the target for creating the archive

Tried tar/untar using ubuntu-latest docker image used by the workflow and the lacework-dev/soluble-cli workflow which unpacks the tar