### PR TITLE
bug(COD-641): fix cloudformation template detection when it is not formated as string

### DIFF
--- a/pkg/inventory/cloudformation_test.go
+++ b/pkg/inventory/cloudformation_test.go
@@ -25,7 +25,9 @@ func TestCloudformationDetector(t *testing.T) {
 AWSTemplateFormatVersion: '2010-09-09'`, true},
 		{"foo.yml", `---
 AWSTemplateFormatVersion: '2010-09-09'`, true},
-		{"foo.yaml", "#AWSTemplateFormatVersion: '2010-09-09", false},
+		{"foo.yml", `---
+AWSTemplateFormatVersion: 2010-09-09`, true},
+		{"foo.yaml", "#AWSTemplateFormatVersion: '2010-09-09'", false},
 		{"foo.json", `{ "AWSTemplateFormatVersion" :
 		"2010-09-09", "bar": 1`, true},
 	}

--- a/pkg/inventory/content.go
+++ b/pkg/inventory/content.go
@@ -16,6 +16,7 @@ package inventory
 
 import (
 	"os"
+	"fmt"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -61,9 +62,7 @@ func decodeYAML(buf []byte) map[string]string {
 	_ = yaml.Unmarshal(buf, &m)
 	r := map[string]string{}
 	for k, v := range m {
-		if s, ok := v.(string); ok {
-			r[k] = s
-		}
+		r[k] = fmt.Sprintf("%v", v)
 	}
 	return r
 }

--- a/pkg/inventory/content.go
+++ b/pkg/inventory/content.go
@@ -15,8 +15,8 @@
 package inventory
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/tidwall/gjson"


### PR DESCRIPTION
Signed-off-by: Hemanth Gokavarapu <hemanth.gokavarapu@lacework.net>

## Testing
- Fixed the test case to make sure it detects the non string yaml file for `AWSTemplateFormatVersion`