### PR TITLE
fix(COD-104) simplify custom policy download and build in safety for parallel execution of the CLI

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/soluble-ai/soluble-cli/pkg/policy/policyimporter"
 
@@ -200,26 +199,11 @@ func downloadCommand() *cobra.Command {
 		m manager.M
 	)
 	c := &cobra.Command{
-		Use:   "download",
-		Short: "Download Lacework and custom opal policies.",
+		Use:    "download",
+		Short:  "Download Lacework and custom opal policies.",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			apiClient, err := m.GetAPIClient()
-			if err != nil {
-				return err
-			}
-			if apiClient.LegacyAPIToken == "" && apiClient.LaceworkAPIToken == "" {
-				return nil
-			}
-			url := "/api/v1/org/{org}/policies/opal/policies.zip"
-			d, err := m.InstallAPIServerArtifact(fmt.Sprintf("opal-%s-policies",
-				apiClient.Organization), url, 1*time.Minute)
-			if err != nil {
-				return err
-			}
-			err = tools.ExtractArchives(d.Dir, []string{"policies.zip", "lacework_policies.zip"})
-			if err != nil {
-				return err
-			}
+			log.Infof("This command is deprecated")
 			return nil
 		},
 	}

--- a/pkg/policy/opal/opal_test.go
+++ b/pkg/policy/opal/opal_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/soluble-ai/soluble-cli/pkg/tools/opal"
+	"github.com/soluble-ai/soluble-cli/pkg/util"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/soluble-ai/soluble-cli/pkg/api"
 	"github.com/soluble-ai/soluble-cli/pkg/options"
@@ -66,10 +69,10 @@ func TestGetCustomPoliciesDir204(t *testing.T) {
 	httpmock.RegisterResponder(http.MethodGet,
 		"https://api.test/api/v1/org/1234/policies/opal/policies.zip",
 		httpmock.NewBytesResponder(http.StatusNoContent, []byte{}))
-
-	customPoliciesDir, err := o.GetCustomPoliciesDir("opal")
+	customPoliciesDir, err := util.GetTempDirPath()
+	assert.NoError(err)
+	err = opal.DownloadPolicies(client, customPoliciesDir, *o)
 
 	assert.Equal(1, httpmock.GetTotalCallCount())
-	assert.NoError(err)
-	assert.Equal(customPoliciesDir, "")
+	assert.Error(err, "no content")
 }

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -338,8 +338,8 @@ func (m *Store) writePolicyFiles(zipWriter *zip.Writer, policy *Policy) error {
 	})
 }
 
-func (m *Store) GetPolicyUploadMetadata() (map[string]string, error) {
-	dat, err := os.ReadFile(filepath.Join(m.Dir, "policies-upload-metadata.json"))
+func (m *Store) GetPolicyUploadMetadata(filename string) (map[string]string, error) {
+	dat, err := os.ReadFile(filepath.Join(m.Dir, filename))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil

--- a/pkg/tools/assessment.go
+++ b/pkg/tools/assessment.go
@@ -61,8 +61,11 @@ func processResult(result *Result) error {
 		}
 	}
 	result.AddValues(result.Tool.GetToolOptions().GetStandardXCPValues())
-	if len(o.customPolicyMetadata) > 0 {
-		addCustomPolicyMetadata(result, o.customPolicyMetadata)
+	if len(o.CustomPolicyMetadata) > 0 {
+		addCustomPolicyMetadata(result, o.CustomPolicyMetadata)
+	}
+	if len(o.LaceworkPolicyMetadata) > 0 {
+		addLaceworkPolicyMetadata(result, o.LaceworkPolicyMetadata)
 	}
 	if result.Directory != "" {
 		result.UpdateFileFingerprints()
@@ -151,6 +154,22 @@ func writeResultValues(w io.Writer, result *Result) {
 
 func addCustomPolicyMetadata(result *Result, metadata map[string]string) {
 	for k, v := range metadata {
-		result.AddValue(fmt.Sprintf("CUSTOM_POLICY_%s", k), v)
+		key := fmt.Sprintf("CUSTOM_POLICY_%s", k)
+		if key == "CUSTOM_POLICY_UPLOAD_PATH" {
+			log.Infof(fmt.Sprintf("Custom policy reference: %s", strings.TrimPrefix(v, "custom_policies/")))
+		}
+		log.Debugf(fmt.Sprintf("%s: %s", key, v))
+		result.AddValue(key, v)
+	}
+}
+
+func addLaceworkPolicyMetadata(result *Result, metadata map[string]string) {
+	for k, v := range metadata {
+		key := fmt.Sprintf("LACEWORK_POLICY%s", k)
+		if key == "LACEWORK_POLICY_UPLOAD_PATH" {
+			log.Infof(fmt.Sprintf("Lacework policy reference: %s", strings.TrimPrefix(v, "custom_policies/")))
+		}
+		log.Debugf(fmt.Sprintf("%s: %s", key, v))
+		result.AddValue(key, v)
 	}
 }

--- a/pkg/tools/checkov/checkov.go
+++ b/pkg/tools/checkov/checkov.go
@@ -152,13 +152,10 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if t.Framework == "terraform" && t.EnableModuleDownload {
 		dt.AppendArgs("--download-external-modules", "true")
 	}
-	customPoliciesDir, err := t.GetCustomPoliciesDir("checkov", "checkov-py")
-	if err != nil {
-		return nil, err
-	}
-	if customPoliciesDir != "" {
-		dt.AppendArgs("--external-checks-dir", customPoliciesDir)
-		dt.Mount(customPoliciesDir, "/policy")
+
+	if t.PreparedCustomPoliciesDir != "" {
+		dt.AppendArgs("--external-checks-dir", t.PreparedCustomPoliciesDir)
+		dt.Mount(t.PreparedCustomPoliciesDir, "/policy")
 	}
 	for _, varFile := range t.relativeVarFiles {
 		dt.AppendArgs("--var-file", varFile)

--- a/pkg/tools/opal/opal.go
+++ b/pkg/tools/opal/opal.go
@@ -1,9 +1,19 @@
 package opal
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+
+	"github.com/soluble-ai/soluble-cli/pkg/api"
+	"github.com/soluble-ai/soluble-cli/pkg/archive"
+	"github.com/soluble-ai/soluble-cli/pkg/exit"
+	"github.com/soluble-ai/soluble-cli/pkg/log"
+	"github.com/soluble-ai/soluble-cli/pkg/policy"
 
 	"github.com/soluble-ai/go-jnode"
 	"github.com/soluble-ai/soluble-cli/pkg/assessments"
@@ -79,13 +89,57 @@ func (t *Tool) Run() (*tools.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	customPoliciesDir, err := t.GetCustomPoliciesDir("opal")
+
+	// create a unique temp dir for downloaded policies
+	customPoliciesDir, err := util.GetTempDirPath()
 	if err != nil {
 		return nil, err
 	}
+	// if the PreparedCustomPoliciesDir is set, policies are loaded from here and not downloaded
+	preparedPoliciesDir := t.PreparedCustomPoliciesDir
+	if preparedPoliciesDir == "" {
+		apiClient, err := t.GetAPIClient()
+		if err != nil {
+			return nil, err
+		}
+		err = DownloadPolicies(apiClient, customPoliciesDir, t.AssessmentOpts)
+		if err != nil {
+			if errors.Is(err, api.ErrNoContent) {
+				log.Infof("There are no custom policies available for {primary:%s} ", t.Name())
+				return &tools.Result{}, nil
+			}
+			return nil, err
+		}
+		store := policy.NewStore(customPoliciesDir)
+		preparedPoliciesDir, err = os.MkdirTemp("", "policy*")
+		if err != nil {
+			return nil, err
+		}
+		exit.AddFunc(func() { _ = os.RemoveAll(preparedPoliciesDir) })
+		if err := store.LoadPoliciesOfType(policy.GetPolicyType("opal")); err != nil {
+			return nil, err
+		}
+		// policies from the customPoliciesDir download dir are prepared in the preparedPoliciesDir
+		if err := store.PreparePolicies(preparedPoliciesDir); err != nil {
+			return nil, err
+		}
+		md, err := store.GetPolicyUploadMetadata("policies-upload-metadata.json")
+		if err != nil {
+			return nil, err
+		}
+		// used in the final assessment
+		t.AssessmentOpts.CustomPolicyMetadata = md
+		lmd, err := store.GetPolicyUploadMetadata("lacework-policies-upload-metadata.json")
+		if err != nil {
+			return nil, err
+		}
+		t.AssessmentOpts.LaceworkPolicyMetadata = lmd
+	}
+
 	args := []string{"run", "--format", "json"}
-	if customPoliciesDir != "" {
-		args = append(args, "--include", customPoliciesDir)
+	// include downloaded custom policies or local prepared policies in the scan
+	if preparedPoliciesDir != "" {
+		args = append(args, "--include", preparedPoliciesDir)
 	}
 	if t.InputType != "" {
 		args = append(args, "--input-type", t.InputType)
@@ -127,4 +181,42 @@ func (t *Tool) parseResults(result *tools.Result, n *jnode.Node) {
 			},
 		})
 	}
+}
+
+func DownloadPolicies(apiClient *api.Client, dir string, o tools.AssessmentOpts) error {
+	err := os.MkdirAll(dir, 0744)
+	if err != nil {
+		return err
+	}
+	log.Debugf(fmt.Sprintf("Policies downloaded to directory: %s", dir))
+	policyZipPath := filepath.Join(dir, "policies.zip")
+	data, err := apiClient.Download(fmt.Sprintf("/api/v1/org/%s/policies/opal/policies.zip", apiClient.Organization))
+	if err != nil {
+		return err
+	}
+	body := bytes.NewReader(data)
+	policyZipFile, err := os.Create(policyZipPath)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(policyZipFile, body)
+	if err != nil {
+		return err
+	}
+	// check there is a zip
+	err = archive.Do(archive.Unzip, policyZipPath, dir, nil)
+	if err != nil {
+		return err
+	}
+	if o.DisableCustomPolicies && o.PreparedCustomPoliciesDir == "" {
+		// assume disable custom policies does not mean disable lacework policies
+		err = tools.ExtractArchives(dir, []string{"lacework_policies.zip"})
+	} else {
+		err = tools.ExtractArchives(dir, []string{"policies.zip", "lacework_policies.zip"})
+	}
+
+	if err != nil {
+		return err
+	}
+	return err
 }

--- a/pkg/tools/runopts.go
+++ b/pkg/tools/runopts.go
@@ -20,7 +20,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/soluble-ai/go-jnode"
 	"github.com/soluble-ai/soluble-cli/pkg/download"
@@ -154,20 +153,6 @@ func (o *RunOpts) getToolVersion(name string) (*jnode.Node, error) {
 		return nil, err
 	}
 	return n, nil
-}
-
-func (o *RunOpts) InstallAPIServerArtifact(name, urlPath string, cacheDuration time.Duration) (*download.Download, error) {
-	apiClient, err := o.GetAPIClient()
-	if err != nil {
-		return nil, err
-	}
-	m := download.NewManager()
-	return m.Install(&download.Spec{
-		Name:                       name,
-		APIServerArtifact:          urlPath,
-		APIServer:                  apiClient,
-		LatestReleaseCacheDuration: cacheDuration,
-	})
 }
 
 func (o *RunOpts) ExecuteCommand(c *exec.Cmd) *ExecuteResult {

--- a/pkg/util/tempdir.go
+++ b/pkg/util/tempdir.go
@@ -39,11 +39,17 @@ func GetRootTempDir() string {
 // GetTempFilePath - return a unique absolute path for a file with filename
 func GetTempFilePath(filename string) (string, error) {
 	// create a unique tmp dir
-	dir, err := os.MkdirTemp(rootTempDir, "*")
+	dir, err := GetTempDirPath()
 	if err != nil {
 		return "", err
 	}
 	// create the absolute file path
 	path := filepath.Join(dir, filename)
 	return path, nil
+}
+
+// GetTempDirPath - return a unique absolute path for a dir
+func GetTempDirPath() (string, error) {
+	// create a unique tmp dir
+	return os.MkdirTemp(rootTempDir, "*")
 }


### PR DESCRIPTION
Simplified download of custom policies.

This update removes the `GetCustomPoliciesDir` from `assessmentopts.go`. Custom policies are for opal only and should not be downloaded by checkov or anything else. The download has been simplified and will use a temporary directory to download policies to for a scan. There is no local cached directory of policies. The `policy download` has been deprecated and does nothing now that each scan will download policies to a temporary location. We have never used policy download as intended (from iacbot before doing a parallel scan) and in new world opal will look at new solutions, moving to each scan using it's own temporary cache of policies improves our parallel posture.  

Notable changes:

 * Deprecation of hidden command `policy download`
 * Download by opal only
 * Updates to tests
 
NB. This code is still adding environment variables with `CUSTOM_POLICY_` prefix to the assessment params. COD-614 will handle that