### PR TITLE
fix(COD-702) quick fix to exit 0 if we can't download opal

### DIFF
--- a/cmd/policy/integration/integration_test.go
+++ b/cmd/policy/integration/integration_test.go
@@ -72,7 +72,7 @@ func TestPolicyCreateWizard(t *testing.T) {
 	description := "This is my sample custom policy. There are many like it, but this one is mine."
 	// Run through the wizard
 	cmd.Start()
-	expectAndRespond(assert, c, `Policies directory path:`, "test_custom_policies", 5)
+	expectAndRespond(assert, c, `Policies directory path:`, "test_custom_policies", 10)
 	expectAndRespond(assert, c, `Create policies directory here`, "y", 1)
 	defer os.RemoveAll("test_custom_policies")
 	expectAndRespond(assert, c, `Select provider`, "aws", 1)

--- a/pkg/tools/opal/opal.go
+++ b/pkg/tools/opal/opal.go
@@ -87,7 +87,8 @@ func (t *Tool) Run() (*tools.Result, error) {
 		URL:  "github.com/lacework/opal-releases",
 	})
 	if err != nil {
-		return nil, err
+		log.Errorf("Could not run opal scan %s", err)
+		os.Exit(0)
 	}
 
 	// create a unique temp dir for downloaded policies


### PR DESCRIPTION
Exit 0 if we hit policy download. Quick fix t allow time to bake opal into iacbot image