### PR TITLE
fix(COD-900) support installation of arm64 binaries from github releases

### DIFF
--- a/pkg/download/release_matcher.go
+++ b/pkg/download/release_matcher.go
@@ -65,6 +65,7 @@ var avoidSubstrings = []string{
 var archSubstrings = map[string][]string{
 	"amd64": {"_amd64", "_x86_64", "-64bit", "-amd64"},
 	"386":   {"_386", "_x86", "_i386", "-32bit"},
+	"arm64": {"_arm64", "-arm64"},
 }
 
 var osSubstrings = map[string][]string{
@@ -104,9 +105,9 @@ func isMatchingReleaseName(r, o, a string) bool {
 	return IsMatchingArch(r, a) && IsMatchingOS(r, o)
 }
 
-func IsMatchingArch(r, a string) bool {
+func IsMatchingArch(r, arch string) bool {
 	r = strings.ToLower(r)
-	for _, a := range archSubstrings[a] {
+	for _, a := range archSubstrings[arch] {
 		if strings.Contains(r, a) {
 			return true
 		}

--- a/pkg/download/release_matcher_test.go
+++ b/pkg/download/release_matcher_test.go
@@ -35,6 +35,8 @@ func TestOsArch(t *testing.T) {
 		{"terrascan_1.1.0_Darwin_x86_64.tar.gz", "darwin", "amd64", true},
 		{"tfsec-checkgen-darwin-amd64", "darwin", "amd64", false},
 		{"tfsec-darwin-amd64", "darwin", "amd64", true},
+		{"opal_0.2.2_darwin_arm64.tar.gz", "darwin", "arm64", true},
+		{"opal_0.2.2_linux_arm64.tar.gz", "linux", "arm64", true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
https://lacework.atlassian.net/browse/COD-900

Opal arm64 binaries were not installing, release matching code has been updated to accept binaries with _arm64, -arm64 in the filename. Tests added.