### PR TITLE
COD-1049: skip policy id resolution on download

### DIFF
--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -34,6 +34,20 @@ func TestResolvePolicyIDExists(t *testing.T) {
 	assert.Equal(t, errors.New("a policy with id: c-mock-a-test-policy already exists"), err)
 }
 
+func TestLoadSinglePolicyCustom(t *testing.T) {
+	store := NewDownloadStore("testdata")
+	policy, err := store.LoadSinglePolicy(GetPolicyType("opal"), "testdata/downloadedpolicies/opal/downloaded_custom_policy")
+	assert.NoError(t, err)
+	assert.Equal(t, policy.ID, "c-opl-downloaded-custom-policy")
+}
+
+func TestLoadSinglePolicyLacework(t *testing.T) {
+	store := NewDownloadStore("testdata")
+	policy, err := store.LoadSinglePolicy(GetPolicyType("opal"), "testdata/downloadedpolicies/opal/downloaded_iac_aws_iam_1")
+	assert.NoError(t, err)
+	assert.Equal(t, policy.ID, "lacework-downloaded-iac-aws-iam-1")
+}
+
 func assertPolicyIDOkay(t *testing.T, store *Store, path string, expected string) {
 	policyID, err := store.resolvePolicyID(mockPolicyType{}, path)
 	assert.Equal(t, expected, policyID)

--- a/pkg/policy/testdata/downloadedpolicies/opal/downloaded_custom_policy/metadata.yaml
+++ b/pkg/policy/testdata/downloadedpolicies/opal/downloaded_custom_policy/metadata.yaml
@@ -1,0 +1,10 @@
+---
+category: "Logging"
+checkTool: "opal"
+checkType: "Terraform"
+description: "an example of a custom policy"
+policyId: "c-opl-downloaded-custom-policy"
+provider: "AWS"
+severity: "Medium"
+sid: "c-opl-downloaded-custom-policy"
+title: "Sample Custom Policy"

--- a/pkg/policy/testdata/downloadedpolicies/opal/downloaded_iac_aws_iam_1/metadata.yaml
+++ b/pkg/policy/testdata/downloadedpolicies/opal/downloaded_iac_aws_iam_1/metadata.yaml
@@ -1,0 +1,11 @@
+---
+category: "IAM"
+checkTool: "opal"
+checkType: "Terraform"
+description: "Amazon Relational Database Service (Amazon RDS) is a web service that makes it easier to set up, operate, and scale a relational database in the AWS Cloud. You can authenticate to your DB cluster using AWS Identity and Access Management (IAM) database authentication. IAM database cluster authentication works with MySQL and PostgreSQL. With this authentication method, you don't need to use a password when you connect to a DB cluster. Instead, you use an authentication token."
+policyId: "lacework-downloaded-iac-aws-iam-1"
+provider: "AWS"
+severity: "Medium"
+sid: "lacework-downloaded-iac-aws-iam-1"
+title: "Ensure RDS cluster has IAM authentication enabled"
+upload reference: "custom_policies/188722aeed4/9e9cd44f-50b9-4bbe-af60-2dbae4e65310"

--- a/pkg/tools/opal/opal.go
+++ b/pkg/tools/opal/opal.go
@@ -111,7 +111,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 	// if CustomPoliciesDir is present prepare those policies and use them for a local assessment
 	// overriding upload flag and PreparedCustomPoliciesDir
 	if t.CustomPoliciesDir != "" {
-		store := policy.NewStore(t.CustomPoliciesDir)
+		store := policy.NewDownloadStore(t.CustomPoliciesDir)
 		preparedPoliciesDir, err := os.MkdirTemp("", "policy*")
 		if err != nil {
 			return nil, err
@@ -141,7 +141,7 @@ func (t *Tool) Run() (*tools.Result, error) {
 			}
 			return nil, err
 		}
-		store := policy.NewStore(customPoliciesDir)
+		store := policy.NewDownloadStore(customPoliciesDir)
 		preparedPoliciesDir, err = os.MkdirTemp("", "policy*")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### JIRA
https://lacework.atlassian.net/browse/COD-1049

### Description
skip resolution of downloaded policy IDs to avoid overwriting with incorrect ID.

### Test
Uploaded a custom policy
Ran a scan that downloaded lacework and custom policies to ensure assessment had correct IDs for both
Added unit tests for `SkipPolicyIDResolution`
