### PR TITLE
Post the enriched assessment json data to CDS so that railgun can process that easily

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -390,18 +390,18 @@ func getFilesForCDS(req *resty.Request, files []string, values map[string]string
 		if err != nil {
 			return nil, err
 		}
-		env_variables_file, err := writeToFile("env_variables.json", jsonContent)
+		envVariablesFile, err := writeToFile("env_variables.json", jsonContent)
 		if err != nil {
 			return nil, err
 		}
-		files = append(files, env_variables_file)
+		files = append(files, envVariablesFile)
 
 		// add the enhanced result json file also to the CDS upload
-		enriched_results_file, err := writeToFile("enriched_results.json", []byte(result.String()))
+		enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(result.String()))
 		if err != nil {
 			return nil, err
 		}
-		files = append(files, enriched_results_file)
+		files = append(files, enrichedResultsFile)
 	}
 	return files, nil
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -391,10 +391,16 @@ func getFilesForCDS(req *resty.Request, files []string, values map[string]string
 			return nil, err
 		}
 		env_variables_file, err := writeToFile("env_variables.json", jsonContent)
+		if err != nil {
+			return nil, err
+		}
 		files = append(files, env_variables_file)
 
 		// add the enhanced result json file also to the CDS upload
 		enriched_results_file, err := writeToFile("enriched_results.json", []byte(result.String()))
+		if err != nil {
+			return nil, err
+		}
 		files = append(files, enriched_results_file)
 	}
 	return files, nil

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -303,6 +303,8 @@ func (c *Client) XCPPost(module string, files []string, values map[string]string
 		// CDS upload shouldn't block the other things at the moment
 		// return nil, err
 		// }
+	} else {
+		log.Debugf("Skipping the upload of results to CDS")
 	}
 	return result, nil
 }


### PR DESCRIPTION
Signed-off-by: Hemanth Gokavarapu <hemanth.gokavarapu@lacework.net>

## JIRA
https://lacework.atlassian.net/browse/COD-1082

## Description
We made a decision to send only the enhanced assessment json file to railgun to unblock ourselves and also to reduce the complexity of processing in railgun where we don't have much control.

<img width="1396" alt="Screen Shot 2023-06-02 at 9 13 59 AM" src="https://github.com/soluble-ai/soluble-cli/assets/5942165/e2113364-ad8b-44b7-95f2-bec82a1f088c">

<img width="1528" alt="Screen Shot 2023-06-02 at 9 59 50 AM" src="https://github.com/soluble-ai/soluble-cli/assets/5942165/8e7e263d-8070-441a-b912-17346394b161">
