### PR TITLE
Post only the enriched assessment content rather than the other duplicate fields

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -400,7 +400,7 @@ func getFilesForCDS(req *resty.Request, files []string, values map[string]string
 
     assessment := result.Path("assessment")
 
-		if assessment != MissingNode {
+		if assessment != jnode.MissingNode {
 			// add the enhanced result json file also to the CDS upload
 			enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(assessment.String()))
 			if err != nil {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -379,7 +379,7 @@ func CloseableOptionFunc(f func(req *resty.Request), close func() error) Option 
 }
 
 // function to get the dirty work done for writing files to CDS
-func getFilesForCDS(req *resty.Request, files []string, values map[string]string, result *jnode.NoPath("assessment")de) ([]string, error) {
+func getFilesForCDS(req *resty.Request, files []string, values map[string]string, result *jnode.Node) ([]string, error) {
 	if len(files) == 0 {
 		for _, v := range req.FormData {
 			files = append(files, v[0])
@@ -402,7 +402,7 @@ func getFilesForCDS(req *resty.Request, files []string, values map[string]string
 
 		if assessment != MissingNode {
 			// add the enhanced result json file also to the CDS upload
-			enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(result.Path("assessment").String()))
+			enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(assessment.String()))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -398,11 +398,9 @@ func getFilesForCDS(req *resty.Request, files []string, values map[string]string
 		}
 		files = append(files, envVariablesFile)
 
-    assessment := result.Path("assessment")
-
-		if assessment != jnode.MissingNode {
+		if result.Path("assessment") != jnode.MissingNode {
 			// add the enhanced result json file also to the CDS upload
-			enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(assessment.String()))
+			enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(result.Path("assessment").String()))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -379,7 +379,7 @@ func CloseableOptionFunc(f func(req *resty.Request), close func() error) Option 
 }
 
 // function to get the dirty work done for writing files to CDS
-func getFilesForCDS(req *resty.Request, files []string, values map[string]string, result *jnode.Node) ([]string, error) {
+func getFilesForCDS(req *resty.Request, files []string, values map[string]string, result *jnode.NoPath("assessment")de) ([]string, error) {
 	if len(files) == 0 {
 		for _, v := range req.FormData {
 			files = append(files, v[0])
@@ -398,12 +398,16 @@ func getFilesForCDS(req *resty.Request, files []string, values map[string]string
 		}
 		files = append(files, envVariablesFile)
 
-		// add the enhanced result json file also to the CDS upload
-		enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(result.String()))
-		if err != nil {
-			return nil, err
+    assessment := result.Path("assessment")
+
+		if assessment != MissingNode {
+			// add the enhanced result json file also to the CDS upload
+			enrichedResultsFile, err := writeToFile("enriched_results.json", []byte(result.Path("assessment").String()))
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, enrichedResultsFile)
 		}
-		files = append(files, enrichedResultsFile)
 	}
 	return files, nil
 }


### PR DESCRIPTION
Signed-off-by: Hemanth Gokavarapu <hemanth.gokavarapu@lacework.net>

https://lacework.atlassian.net/browse/COD-1108

Entire assessment result has duplicate stuff and it is not necessary to send all those duplicate things and increasing the size of file being posted to railgun. This also decreases the complexity of deserializing in the railgun side.


