### PR TITLE
fix(COD-925): policy test should not ignore TF load errors

### DIFF
--- a/pkg/policy/opal/opal_test.go
+++ b/pkg/policy/opal/opal_test.go
@@ -40,6 +40,34 @@ func TestPoliciesFail(t *testing.T) {
 	assert.Equal(1, tm.Passed)
 }
 
+// By default we do not fail for "strict" cases
+func TestNonStrictPolicies(t *testing.T) {
+	assert := assert.New(t)
+	m := &manager.M{}
+	err := m.DetectPolicy("testdata/strictfail/policies")
+	assert.NoError(err)
+	assert.Equal(1, len(m.Policies))
+	tm, err := m.TestPolicies()
+	assert.NoError(err)
+	assert.Equal(0, tm.Failed)
+	// Ensure we get all results
+	assert.Equal(4, tm.Passed)
+}
+
+// Fail for "strict" cases when StrictLoading is true
+func TestStrictPoliciesFail(t *testing.T) {
+	assert := assert.New(t)
+	m := &manager.M{}
+	m.StrictLoading = true
+	err := m.DetectPolicy("testdata/strictfail/policies")
+	assert.NoError(err)
+	assert.Equal(1, len(m.Policies))
+	tm, err := m.TestPolicies()
+	assert.Error(err)
+	assert.Equal(1, tm.Failed)
+	assert.Equal(4, tm.Passed)
+}
+
 func TestGetCustomPoliciesDir204(t *testing.T) {
 	assert := assert.New(t)
 	apiConfig := &api.Config{

--- a/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/metadata.yaml
+++ b/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/metadata.yaml
@@ -1,0 +1,14 @@
+category: Compute
+checkTool: opal
+checkType:
+    - Terraform
+description: "Network firewall rules should not permit ingress from 0.0.0.0/0 to port 22 (SSH). If SSH is open to the internet, attackers can attempt to gain access to VM instances. Removing unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk."
+provider: GCP
+severity: High
+title: "Network firewall rules should not permit ingress from 0.0.0.0/0 to port 22 (SSH)"
+id: "lacework-opl-compute-firewall-port-22"
+lwids:
+    CIS-Google_v1.1.0:
+        - CIS-Google_v1.1.0_3.6
+    CIS-Google_v1.2.0:
+        - CIS-Google_v1.2.0_3.6

--- a/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/policy.rego
+++ b/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/policy.rego
@@ -1,0 +1,25 @@
+package policies.tf_google_compute_firewall_port_22
+
+import data.google.compute.firewall_library as lib
+import data.lacework
+
+
+firewalls = lacework.resources("google_compute_firewall")
+
+resource_type := "MULTIPLE"
+
+port = "22"
+
+policy[j] {
+  firewall = firewalls[_]
+  network = lib.network_for_firewall(firewall)
+  lib.is_network_vulnerable(network, port)
+  j = lacework.allow_resource(firewall)
+} {
+  firewall = firewalls[_]
+  network = lib.network_for_firewall(firewall)
+  not lib.is_network_vulnerable(network, port)
+  p = lib.lowest_allow_ingress_zero_cidr_by_port(network, port)
+  f = lib.firewalls_by_priority_and_port(network, p, port)[_]
+  j = lacework.deny_resource(f)
+}

--- a/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/fail/inputs/invalid_firewall_deny_then_allow.tf
+++ b/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/fail/inputs/invalid_firewall_deny_then_allow.tf
@@ -1,0 +1,27 @@
+provider google { alias = "google6" }
+
+resource "google_compute_network" "test6" {
+  name = "test-network6"
+}
+
+resource "google_compute_firewall" "deny_all" {
+  name          = "deny-all"
+  network       = google_compute_network.test6.name
+  source_ranges = ["0.0.0.0/0"]
+
+  deny {
+    protocol = "all"
+  }
+}
+
+resource "google_compute_firewall" "allow_ports" {
+  name          = "allow-ports"
+  network       = google_compute_network.test6.name
+  source_ranges = ["0.0.0.0/0"]
+  priority      = 1
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "3389"]
+  }
+}

--- a/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/fail/inputs/invalid_firewall_multiple_networks.tf
+++ b/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/fail/inputs/invalid_firewall_multiple_networks.tf
@@ -1,0 +1,36 @@
+# This test case has repeated resource names and opal will not be able to load it,=.
+# This case is skipped by opal and does not appear in the results; unless ---strict-loading is
+# set, in which case the test fails.
+
+provider google { alias = "google9" }
+
+resource "google_compute_network" "test1" {
+  name = "test-network1"
+}
+
+resource "google_compute_firewall" "deny_all" {
+  name          = "deny-all"
+  network       = google_compute_network.test1.name
+  source_ranges = ["0.0.0.0/0"]
+  priority      = 1
+
+  deny {
+    protocol = "all"
+  }
+}
+
+resource "google_compute_network" "test2" {
+  name = "test-network2"
+}
+
+resource "google_compute_firewall" "allow_ports1" {
+  name          = "allow-ports1"
+  network       = google_compute_network.test2.name
+  source_ranges = ["0.0.0.0/0"]
+  priority      = 1000
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "3389"]
+  }
+}

--- a/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/pass/inputs/valid_firewall_allow_port_range.tf
+++ b/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/pass/inputs/valid_firewall_allow_port_range.tf
@@ -1,0 +1,16 @@
+provider google {}
+
+resource "google_compute_network" "test" {
+  name = "test-network"
+}
+
+resource "google_compute_firewall" "allow_all" {
+  name = "allow-all"
+  network = google_compute_network.test.name
+  source_ranges = [ "0.0.0.0/0" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ "23-30", "3380-3388", "3390-3399" ]
+  }
+}

--- a/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/pass/inputs/valid_firewall_restricted_allow.tf
+++ b/pkg/policy/opal/testdata/strictfail/policies/opal/compute_firewall_port_22/terraform/tests/pass/inputs/valid_firewall_restricted_allow.tf
@@ -1,0 +1,16 @@
+provider google { alias = "google6" }
+
+resource "google_compute_network" "test6" {
+  name = "test-network6"
+}
+
+resource "google_compute_firewall" "restricted_allow" {
+  name = "restricted-allow"
+  network = google_compute_network.test6.name
+  source_ranges = [ "98.233.183.221/32" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ "22", "3389" ]
+  }
+}

--- a/pkg/tools/opal/opal.go
+++ b/pkg/tools/opal/opal.go
@@ -195,6 +195,9 @@ func (t *Tool) Run() (*tools.Result, error) {
 	for _, varFile := range t.GetVarFiles() {
 		args = append(args, "--var-file", varFile)
 	}
+	if t.RunOpts.StrictLoading {
+		args = append(args, "--strict-loading")
+	}
 	args = append(args, t.ExtraArgs...)
 	args = append(args, ".")
 	// #nosec G204

--- a/pkg/tools/runopts.go
+++ b/pkg/tools/runopts.go
@@ -39,6 +39,7 @@ type RunOpts struct {
 	NoDocker        bool
 	Internal        bool
 	quiet           bool
+	StrictLoading   bool
 }
 
 var _ options.Interface = &RunOpts{}
@@ -53,6 +54,7 @@ func (o *RunOpts) GetRunHiddenOptions() *options.HiddenOptionsGroup {
 			flags.StringVar(&o.ToolPath, "tool-path", "", "Run `tool` directly instead of using a CLI-managed version")
 			flags.StringVar(&o.ToolVersion, "tool-version", "", "Override version of the tool to run (the image or github release name.)")
 			flags.BoolVar(&o.NoDocker, "no-docker", false, "Always run tools locally instead of using Docker")
+			flags.BoolVar(&o.StrictLoading, "strict-loading", false, "If the scan tool should fail when warnings occur when loading a file. Currently only applicable to opal terraform")
 		},
 	}
 }


### PR DESCRIPTION
Stops our policy testing from glossing over bad test input files.
Defaults to false to avoid scanning being too strict for customers.

Example output BEFORE this change:

```
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_allow_all.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_allow_port_range.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_allow_ports.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_deny_then_allow.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_equal_priorities.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_multiple_networks.tf fail terraform - OK
[ Info] Ran 14 tests and all passed
```

Output with this change:

```
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_allow_all.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_allow_port_range.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_allow_ports.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_deny_then_allow.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_equal_priorities.tf fail terraform - OK
[ Info] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_multiple_networks.tf fail terraform - OK
[Error] Policy policies/opal/compute_firewall_port_22 test invalid_firewall_multiple_networks.tf fail terraform - FAILED
[ Info] Ran 15 tests with 14 passed and 1 failed
```
