### PR TITLE
chore(CI): Do not Slack notify for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           SOLUBLE_API_SERVER: ${{ vars.SOLUBLE_API_SERVER }}
           SOLUBLE_ORGANIZATION: ${{ vars.SOLUBLE_ORGANIZATION }}
       - name: Report Status
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IAC_SLACK_WEBHOOK }}


### PR DESCRIPTION
Humans are already looking at PRs, no need to add an unread message in the team notification channel.