### PR TITLE
COD-1099: upload and process tracker file to manage duplicate findings

### DIFF
--- a/pkg/policy/manager/manager.go
+++ b/pkg/policy/manager/manager.go
@@ -70,7 +70,7 @@ func (m *M) RegisterUpload(cmd *cobra.Command) {
 	flags.StringVarP(&m.Dir, "directory", "d", "", "Load policies from this directory. Path should point to the parent directory of your /policies directory.")
 	flags.StringVar(&m.ConvertedPoliciesFile, "converted-policies-file", "", "Upload file to track converted policies. Path should point to policy_conversion_tracker file")
 	// hidden for internal use only
-	flags.MarkHidden("converted-policies-file")
+	_ = flags.MarkHidden("converted-policies-file")
 }
 
 func (m *M) ValidatePolicies() ValidateResult {

--- a/pkg/policy/manager/manager.go
+++ b/pkg/policy/manager/manager.go
@@ -68,6 +68,9 @@ func (m *M) RegisterUpload(cmd *cobra.Command) {
 	m.RunOpts.Register(cmd)
 	flags := cmd.Flags()
 	flags.StringVarP(&m.Dir, "directory", "d", "", "Load policies from this directory. Path should point to the parent directory of your /policies directory.")
+	flags.StringVar(&m.ConvertedPoliciesFile, "converted-policies-file", "", "Upload file to track converted policies. Path should point to policy_conversion_tracker file")
+	// hidden for internal use only
+	flags.MarkHidden("converted-policies-file")
 }
 
 func (m *M) ValidatePolicies() ValidateResult {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -37,7 +37,7 @@ type Policy struct {
 }
 
 type ConvertedOpalPolicies struct {
-	ConvertedPolicies []string `json:"convertedPolicies"`
+	ConvertedPolicies []string
 }
 type Target string
 
@@ -269,7 +269,7 @@ func (m *Store) writeOpalPolicyTracker(zipWriter *zip.Writer) error {
 		return err
 	}
 	header := &zip.FileHeader{
-		Name:               "policies-opal-duplicates.json",
+		Name:               "policies-opal-duplicates.txt",
 		UncompressedSize64: uint64(len(duplicateTrackingFile.ConvertedPolicies)),
 		Modified:           time.Now(),
 		Method:             zip.Deflate,
@@ -280,9 +280,10 @@ func (m *Store) writeOpalPolicyTracker(zipWriter *zip.Writer) error {
 		return err
 	}
 
-	dat, _ := json.Marshal(duplicateTrackingFile)
-	if _, err := ioWriter.Write(dat); err != nil {
-		return err
+	for _, policy := range duplicateTrackingFile.ConvertedPolicies {
+		if _, err := io.WriteString(ioWriter, policy+"\n"); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -270,7 +270,7 @@ func (m *Store) writeOpalPolicyTracker(zipWriter *zip.Writer) error {
 		return err
 	}
 	header := &zip.FileHeader{
-		Name:               fmt.Sprintf("opal-duplicates.json"),
+		Name:               fmt.Sprintf("policies-opal-duplicates.json"),
 		UncompressedSize64: uint64(len(duplicateTrackingFile.ConvertedPolicies)),
 		Modified:           time.Now(),
 		Method:             zip.Deflate,

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -257,7 +257,6 @@ func (m *Store) writeUploadMetadata(zipWriter *zip.Writer) error {
 }
 
 func (m *Store) writeOpalPolicyTracker(zipWriter *zip.Writer) error {
-
 	opalPolicyMappings, err := os.ReadFile(m.ConvertedPoliciesFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -270,7 +269,7 @@ func (m *Store) writeOpalPolicyTracker(zipWriter *zip.Writer) error {
 		return err
 	}
 	header := &zip.FileHeader{
-		Name:               fmt.Sprintf("policies-opal-duplicates.json"),
+		Name:               "policies-opal-duplicates.json",
 		UncompressedSize64: uint64(len(duplicateTrackingFile.ConvertedPolicies)),
 		Modified:           time.Now(),
 		Method:             zip.Deflate,

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -67,7 +67,7 @@ func TestGetPublishedPolicyMappings(t *testing.T) {
 
 	var expected []string
 	expected = append(expected, "ckv-aws-1", "tfsec-aws2", "ckv-aws-2")
-	assert.Equal(t, expected, duplicateTrackingFile.ConvertedPolicies)
+	assert.ElementsMatch(t, expected, duplicateTrackingFile.ConvertedPolicies)
 }
 
 func assertPolicyIDOkay(t *testing.T, store *Store, path string, expected string) {

--- a/pkg/policy/testdata/policy_conversion_tracker.json
+++ b/pkg/policy/testdata/policy_conversion_tracker.json
@@ -1,0 +1,7 @@
+{
+  "iac_aws_iam_1": ["ckv-aws-1"],
+  "iac_aws_iam_2": ["tfsec-aws2", "ckv-aws-2"],
+  "iac_aws_iam_3": ["ckv-aws-3"],
+  "iac_aws_iam_4": ["tfsec-aws4", "ckv-aws-4"],
+  "iac_aws_iam_5": ["tfsec-aws5"]
+}


### PR DESCRIPTION
### JIRA
https://lacework.atlassian.net/browse/COD-1099

### Description 

(This comes with an api-server change also) - file will not be included in upload bundle without the api-server change

Add hidden flag `--converted-policies-file` to upload command.
Process the file so that:
-  we only extract the published converted policies ( the file contains mappings from staging too)
- we create a file to upload (called "policies-opal-duplicates.json")  that has a list of "old" policies to skip ( When we make use of this file we wont need to know all the mappings we just need to know what policies to skip)

Upload the  "policies-opal-duplicates.txt" file as part of the policies bundle. 
File name must start with "policies" to be accepted by the api-server

This flag will be added to the Github actions so that whenever we publish policies an up to date list of policies to skip becomes available.
File content will be a newline separated list of "old" policy IDs:
<img width="426" alt="image" src="https://github.com/soluble-ai/soluble-cli/assets/81188241/1300905f-15c1-4885-a72b-092fbc0f747f">



### Test
Unit test added to validate processing of mappings
